### PR TITLE
Review compiled PDFs with a Cursor model panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,11 @@ Each of those is a **paper** task, and it walks a fixed pipeline:
 3. **Rounds** — by default ten of them. The author agent works in the task's tmux
    pane (revising the paper, running experiments locally in the worktree) and
    signals the end of its turn by writing `rounds/round-NN/author.md`. Loom then
-   compiles the PDF and runs a reviewer agent headlessly, with a different model,
-   against a top-conference rubric; its scores and report drive the next round.
+   compiles the PDF and runs three independent Cursor reviewers headlessly:
+   `gpt-5.6-sol-max`, `claude-fable-5-thinking-max`, and
+   `cursor-grok-4.5-high`. Each reviewer sees an isolated workspace containing
+   only the compiled PDF (never the LaTeX source); their reports and
+   deterministically aggregated scores drive the next round.
 4. **Final review** — a gate. Approve to deliver and download the PDF, or send it
    back for another batch of rounds.
 

--- a/loom/ar_task.py
+++ b/loom/ar_task.py
@@ -27,8 +27,10 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
 from loom.paths import bundled_skills_path, paper_templates_dir
@@ -87,6 +89,18 @@ MAX_ROUNDS_LIMIT = 50
 
 MODE_AUTO = "auto"
 MODE_SEED = "seed"
+
+# Cursor's account-scoped model catalog exposes these as the strongest
+# non-fast variants currently available for the requested reviewer families.
+# Fable has an explicit Thinking variant. GPT-5.6 Sol and Cursor Grok do not
+# expose a separate Thinking switch; max/high is their strongest reasoning
+# preset, and Cursor intentionally suppresses private reasoning in print mode.
+CURSOR_REVIEWER_MODELS: tuple[str, ...] = (
+    "gpt-5.6-sol-max",
+    "claude-fable-5-thinking-max",
+    "cursor-grok-4.5-high",
+)
+CURSOR_REVIEWER_PANEL = "cursor-reviewer-panel"
 
 
 # --- Catalogs ---------------------------------------------------------------
@@ -425,6 +439,7 @@ def new_paper_state(
     max_rounds: Any = DEFAULT_MAX_ROUNDS,
     author_model: str = "",
     reviewer_model: str = "",
+    reviewer_models: list[str] | tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
     v = (venue or "").strip().lower()
     if v not in VENUE_IDS:
@@ -443,7 +458,11 @@ def new_paper_state(
         "gates": [],
         "loop_running": False,
         "author_model": author_model,
+        # Keep the singular field so old ar.json readers remain compatible.
         "reviewer_model": reviewer_model,
+        "reviewer_models": list(
+            CURSOR_REVIEWER_MODELS if reviewer_models is None else reviewer_models
+        ),
         "paper_dir": "",
         "pdf_path": "",
         "pdf_built_at": "",
@@ -1322,6 +1341,180 @@ def review_headline(scores: dict[str, Any]) -> str:
     return " · ".join(bits) or "no scores parsed"
 
 
+def _cursor_models(timeout: int = 30) -> dict[str, Any]:
+    """Return the model ids advertised by the logged-in Cursor CLI account."""
+    try:
+        proc = subprocess.run(
+            ["agent", "models"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "error": "Cursor CLI `agent` is not on PATH", "models": []}
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"ok": False, "error": f"could not list Cursor models: {exc}", "models": []}
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "unknown error").strip()
+        return {
+            "ok": False,
+            "error": f"`agent models` failed: {detail[-1000:]}",
+            "models": [],
+        }
+    models: list[str] = []
+    for line in (proc.stdout or "").splitlines():
+        match = re.match(r"^([a-zA-Z0-9][a-zA-Z0-9._-]*)\s+-\s+", line.strip())
+        if match:
+            models.append(match.group(1))
+    return {"ok": True, "models": models}
+
+
+def _run_cursor_headless(
+    prompt: str,
+    model: str,
+    workspace: Path,
+    *,
+    timeout: int = 900,
+    on_line: Any = None,
+) -> dict[str, Any]:
+    """Run one read-only Cursor reviewer and return its final Markdown.
+
+    Cursor's print mode never exposes private thinking tokens. The selected
+    model id controls the maximum available reasoning budget; Ask mode and the
+    absence of ``--force`` keep this reviewer read-only.
+    """
+    cmd = [
+        "agent",
+        "--print",
+        "--workspace",
+        str(workspace),
+        "--mode",
+        "ask",
+        "--trust",
+        "--model",
+        model,
+        "--output-format",
+        "json",
+        prompt,
+    ]
+    if on_line is not None:
+        on_line(f"{model}: reviewing compiled PDF")
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(workspace),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "model": model, "error": "Cursor CLI `agent` is not on PATH"}
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "model": model,
+            "error": f"Cursor review timed out after {timeout}s",
+        }
+    except OSError as exc:
+        return {"ok": False, "model": model, "error": str(exc)}
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "unknown error").strip()
+        return {
+            "ok": False,
+            "model": model,
+            "error": f"Cursor reviewer exited {proc.returncode}: {detail[-1500:]}",
+        }
+    try:
+        payload = json.loads(proc.stdout or "")
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "model": model,
+            "error": f"Cursor reviewer returned invalid JSON: {exc}",
+            "raw": (proc.stdout or "")[-1500:],
+        }
+    if not isinstance(payload, dict):
+        return {"ok": False, "model": model, "error": "Cursor reviewer JSON is not an object"}
+    if payload.get("is_error") is True or payload.get("subtype") == "error":
+        return {
+            "ok": False,
+            "model": model,
+            "error": str(payload.get("result") or payload.get("error") or "Cursor review failed"),
+        }
+    text = str(payload.get("result") or "").strip()
+    if not text:
+        return {"ok": False, "model": model, "error": "Cursor reviewer returned no result"}
+    scores = parse_review_scores(text)
+    elapsed = round(time.monotonic() - started, 1)
+    if on_line is not None:
+        on_line(f"{model}: {review_headline(scores)} ({elapsed}s)")
+    return {
+        "ok": True,
+        "model": model,
+        "review": text,
+        "scores": scores,
+        "headline": review_headline(scores),
+        "duration_seconds": elapsed,
+    }
+
+
+def _panel_scores(reviewers: list[dict[str, Any]]) -> dict[str, Any]:
+    """Deterministically summarize three independent reviewer score blocks."""
+    aggregate: dict[str, Any] = {}
+    for field in _SCORE_FIELDS:
+        values = sorted(
+            float(scores[field])
+            for item in reviewers
+            if isinstance((scores := item.get("scores")), dict) and field in scores
+        )
+        if values:
+            value = values[len(values) // 2]
+            aggregate[field] = int(value) if value.is_integer() else value
+    recommendations = [
+        str((item.get("scores") or {}).get("recommendation") or "")
+        for item in reviewers
+    ]
+    ranked = sorted(
+        (RECOMMENDATIONS.index(rec), rec)
+        for rec in recommendations
+        if rec in RECOMMENDATIONS
+    )
+    if ranked:
+        aggregate["recommendation"] = ranked[len(ranked) // 2][1]
+    return aggregate
+
+
+def _cursor_pdf_review_prompt(
+    skill_text: str,
+    *,
+    pdf_path: Path,
+    venue: str,
+    round_n: int,
+) -> str:
+    """Prompt one independent reviewer to judge only the compiled PDF."""
+    return (
+        f"{skill_text}\n\n"
+        "=== end reviewer instructions ===\n\n"
+        f"Venue: {venue_entry(venue).get('label')}\n"
+        f"Review round: {round_n}\n\n"
+        "You are one member of a three-model independent reviewer panel. Use the "
+        "full reasoning budget configured by your model and think deeply before "
+        "returning the report. Do not reveal private chain-of-thought; return only "
+        "the required review.\n\n"
+        "The sole paper artifact for this review is the compiled PDF below:\n"
+        f"{pdf_path}\n\n"
+        "Open and inspect every page of that PDF. Judge both the scientific content "
+        "and the rendered artifact (tables, figures, equations, clipping, legibility, "
+        "and page-level presentation). The PDF is the source of truth. Do not search "
+        "for, open, or infer from LaTeX source files, author notes, experiment code, "
+        "or another review. Review the submission cold and independently.\n\n"
+        "Write your review now, in exactly the required markdown structure."
+    )
+
+
 def run_reviewer(
     paper_dir: Path,
     skill_text: str,
@@ -1331,59 +1524,126 @@ def run_reviewer(
     round_n: int = 1,
     author_note: str = "",
     build: dict[str, Any] | None = None,
-    model: str = "",
+    models: list[str] | tuple[str, ...] | None = None,
     timeout: int = 900,
     on_line: Any = None,
 ) -> dict[str, Any]:
-    """Review the current state of the paper as a program committee member."""
-    source = paper_source_text(paper_dir)
-    if not source:
-        return {"ok": False, "error": f"no LaTeX sources under {paper_dir}"}
+    """Review a compiled PDF with the fixed three-model Cursor panel.
 
+    ``idea`` and ``author_note`` remain accepted for API compatibility, but are
+    deliberately not included: reviewers see the same PDF a human reviewer
+    would receive, not the author's framing or raw LaTeX.
+    """
+    del idea, author_note
     build = build or {}
-    if build.get("ok"):
-        build_line = (
-            "The paper compiles."
-            if build.get("clean")
-            else "The paper compiles with LaTeX warnings/errors."
-        )
-    else:
-        build_line = f"The paper does NOT compile: {build.get('error', 'unknown error')}"
+    pdf_value = str(build.get("pdf") or "").strip()
+    pdf = Path(pdf_value) if pdf_value else paper_dir / "main.pdf"
+    if not build.get("ok") or not pdf.is_file():
+        error = str(build.get("error") or f"compiled PDF not found at {pdf}")
+        return {"ok": False, "error": f"cannot review without a compiled PDF: {error}"}
 
-    idea_block = idea_summary(idea) if idea else "(not recorded)"
-    author_block = (author_note or "").strip() or "(the author left no note this round)"
+    selected = tuple(models or CURSOR_REVIEWER_MODELS)
+    if selected != CURSOR_REVIEWER_MODELS:
+        return {
+            "ok": False,
+            "error": (
+                "reviewer panel must use exactly: "
+                + ", ".join(CURSOR_REVIEWER_MODELS)
+            ),
+        }
+    catalog = _cursor_models()
+    if not catalog.get("ok"):
+        return catalog
+    available = set(catalog.get("models") or [])
+    missing = [model for model in selected if model not in available]
+    if missing:
+        return {
+            "ok": False,
+            "error": "required Cursor reviewer model(s) unavailable: " + ", ".join(missing),
+            "available_models": sorted(available),
+        }
 
-    prompt = (
-        f"{skill_text}\n\n"
-        "=== end reviewer instructions ===\n\n"
-        f"Venue: {venue_entry(venue).get('label')}\n"
-        f"Review round: {round_n}\n"
-        f"Build status: {build_line}\n\n"
-        f"The idea this submission is meant to establish:\n{idea_block}\n\n"
-        f"What the authors say they did this round:\n{author_block}\n\n"
-        "LaTeX sources of the submission follow. Markers such as \\ARTODO{...}, "
-        "\\ARnum{} and \\ARfig{...} are deliberate placeholders for work that has "
-        "not been done yet - treat them as honest gaps, not as claims.\n\n"
-        f"{source}\n\n"
-        "Write your review now, in exactly the required markdown structure."
-    )
     if on_line is not None:
         on_line(
-            f"reviewing round {round_n} as {venue_entry(venue).get('label')} "
-            f"({len(source)} chars of LaTeX)"
+            f"reviewing compiled PDF with Cursor panel: {', '.join(selected)}"
         )
-    res = _run_headless(prompt, model=model, timeout=timeout, on_line=on_line)
-    if not res.get("ok"):
-        return res
-    text = str(res.get("text") or "").strip()
-    scores = parse_review_scores(text)
-    if on_line is not None:
-        on_line(review_headline(scores))
+
+    with TemporaryDirectory(prefix="loom-ar-pdf-review-") as tmp:
+        workspace = Path(tmp)
+        review_pdf = workspace / "submission.pdf"
+        try:
+            shutil.copy2(pdf, review_pdf)
+        except OSError as exc:
+            return {"ok": False, "error": f"could not isolate compiled PDF: {exc}"}
+        prompt = _cursor_pdf_review_prompt(
+            skill_text,
+            pdf_path=review_pdf,
+            venue=venue,
+            round_n=round_n,
+        )
+        by_model: dict[str, dict[str, Any]] = {}
+        with ThreadPoolExecutor(max_workers=len(selected)) as pool:
+            futures = {
+                pool.submit(
+                    _run_cursor_headless,
+                    prompt,
+                    model,
+                    workspace,
+                    timeout=timeout,
+                    on_line=on_line,
+                ): model
+                for model in selected
+            }
+            for future in as_completed(futures):
+                model = futures[future]
+                try:
+                    by_model[model] = future.result()
+                except Exception as exc:  # noqa: BLE001
+                    by_model[model] = {"ok": False, "model": model, "error": str(exc)}
+
+    reviewers = [by_model[model] for model in selected]
+    failures = [item for item in reviewers if not item.get("ok")]
+    if failures:
+        detail = "; ".join(
+            f"{item.get('model')}: {item.get('error', 'unknown error')}"
+            for item in failures
+        )
+        return {
+            "ok": False,
+            "error": f"Cursor reviewer panel incomplete: {detail}",
+            "reviewers": reviewers,
+        }
+
+    scores = _panel_scores(reviewers)
+    headline = f"{len(reviewers)} reviewers · {review_headline(scores)}"
+    sections = [
+        "# Cursor Reviewer Panel",
+        "",
+        f"**Round:** {round_n}",
+        f"**Input:** compiled PDF only (`{pdf.name}`)",
+        f"**Models:** {', '.join(selected)}",
+        f"**Panel summary:** {review_headline(scores)}",
+    ]
+    for item in reviewers:
+        sections.extend(
+            [
+                "",
+                "---",
+                "",
+                f"# Reviewer: `{item['model']}`",
+                "",
+                str(item["review"]).strip(),
+            ]
+        )
+    text = "\n".join(sections).strip() + "\n"
     return {
         "ok": True,
         "review": text,
         "scores": scores,
-        "headline": review_headline(scores),
+        "headline": headline,
+        "models": list(selected),
+        "reviewers": reviewers,
+        "input_pdf": str(pdf),
     }
 
 

--- a/loom/skills/ar/AR-REVIEWER.md
+++ b/loom/skills/ar/AR-REVIEWER.md
@@ -5,6 +5,12 @@ NeurIPS or COLM). Review it the way a competent, busy, slightly skeptical
 reviewer would: read for the claim, check whether the evidence supports it, and
 say so plainly.
 
+Loom gives you an isolated workspace containing the compiled `submission.pdf`
+and no paper source. Open and inspect every page. The PDF is the submission and
+the sole source of truth: do not search for LaTeX, author notes, experiment
+code, raw logs, or another review. Evaluate both the science and what is
+actually rendered on the page.
+
 You are not the author's assistant. Your value to this pipeline comes entirely
 from catching what is wrong, so a review that reads as encouragement is a failed
 review. The author agent reads your output and acts on it in the next round.
@@ -12,17 +18,16 @@ review. The author agent reads your output and acts on it in the next round.
 ## Hard rules
 
 1. **Judge the paper in front of you**, not the paper it could become.
-2. **Every weakness names a location** — a section, a table, an equation — and
-   states what would fix it. "The evaluation is weak" is useless; "Table 1 has
-   no baseline that controls for parameter count, so the gain could be capacity"
-   is actionable.
+2. **Every weakness names a PDF location** — page plus section, table, figure,
+   or equation — and states what would fix it. "The evaluation is weak" is
+   useless; "Page 6, Table 1 has no baseline that controls for parameter count,
+   so the gain could be capacity" is actionable.
 3. **Unsupported numbers are the most serious defect you can find.** If the
-   paper states a result that no described experiment produces, or a `\ARnum{}`
-   marker has been replaced by a number with no experimental setup behind it,
-   flag it as a soundness violation, not a presentation issue.
-4. **Placeholders are expected in early rounds.** A `\ARTODO{}` or `\ARnum{}`
-   is an honest gap; note what is missing and move on. Do not spend the review
-   listing every marker.
+   PDF states a result that no experiment described in the PDF produces, flag
+   it as a soundness violation, not a presentation issue.
+4. **Visible placeholders are expected in early rounds.** Treat clearly marked
+   TODO/result/figure placeholders as honest gaps; note what critical evidence
+   is missing and move on. Do not spend the review listing every placeholder.
 5. **Do not reward effort.** Length, breadth of related work, and number of
    equations do not raise the score. Only evidence for the central claim does.
 6. Be concise. A long review dilutes the points that matter.
@@ -53,7 +58,8 @@ Check specifically:
 One model family or one benchmark supports a narrow claim, not a broad one.
 
 **Presentation.** Only after the above: clarity, notation, figure quality,
-whether the abstract matches the results.
+whether the abstract matches the results, and rendered-PDF defects such as
+clipping, unreadable labels, broken references, missing glyphs, or overflow.
 
 ## Output format
 
@@ -67,7 +73,7 @@ Reply in exactly this markdown structure, and nothing else:
 - <specific, and only if genuine; an empty list is a legitimate outcome>
 
 ## Weaknesses
-- **[critical|major|minor]** `<section or table>` - <what is wrong> -> <what would fix it>
+- **[critical|major|minor]** `<page + section/table/figure/equation>` - <what is wrong> -> <what would fix it>
 
 ## Questions for the authors
 - <questions whose answers would change your score>

--- a/loom/web.py
+++ b/loom/web.py
@@ -3583,10 +3583,10 @@ def _ar_run_async(fn, *args: Any) -> None:
 
 
 def _ar_headless_model(meta: Any) -> str:
-    """Model for headless AR calls.
+    """Claude model for headless Studio idea generation.
 
-    These go through ``claude -p``, so a task configured for Cursor or Codex
-    cannot lend its model id; fall back to the Claude default in that case.
+    Idea generation still goes through ``claude -p``. Paper reviews use the
+    fixed Cursor PDF reviewer panel defined in ``ar_task.py``.
     """
     if meta is not None and normalize_agent(getattr(meta, "agent", "")) == AGENT_CLAUDE:
         model = str(getattr(meta, "interview_model", "") or "").strip()
@@ -3699,7 +3699,7 @@ def _ar_ideas_job(root: Path, slug: str, count: int, model: str) -> None:
         print(f"[ar] {slug}: idea generation failed - {res.get('error')}", flush=True)
 
 
-def _ar_review_job(root: Path, slug: str, model: str) -> None:
+def _ar_review_job(root: Path, slug: str) -> None:
     """One out-of-band review, triggered from the panel rather than the loop."""
     state = ar.read_ar_state(root, slug)
     paper_dir = ar.paper_root(root, slug)
@@ -3711,16 +3711,13 @@ def _ar_review_job(root: Path, slug: str, model: str) -> None:
         if build.get("ok")
         else f"PDF build failed: {build.get('error')}"
     )
-    author_note = _ar_read_text(ar.author_note_path(root, slug, n))
     res = ar.run_reviewer(
         paper_dir,
         ar.ar_skill_text(ar.SKILL_REVIEWER),
         venue=str(state.get("venue") or ar.DEFAULT_VENUE),
-        idea=state.get("idea") or {},
         round_n=max(1, n),
-        author_note=author_note,
         build=build,
-        model=model,
+        models=ar.CURSOR_REVIEWER_MODELS,
         on_line=log,
     )
     if not res.get("ok"):
@@ -3740,10 +3737,19 @@ def _ar_review_job(root: Path, slug: str, model: str) -> None:
     rec = ar.ensure_round(state, n)
     rec["review"] = {
         "created_at": _iso_now(),
-        "model": model,
+        "model": ar.CURSOR_REVIEWER_PANEL,
+        "models": res.get("models") or list(ar.CURSOR_REVIEWER_MODELS),
         "path": str(path),
         "scores": res.get("scores") or {},
         "headline": res.get("headline") or "",
+        "input_pdf": res.get("input_pdf") or str(paper_dir / "main.pdf"),
+        "reviewers": [
+            {
+                key: item.get(key)
+                for key in ("model", "scores", "headline", "duration_seconds")
+            }
+            for item in (res.get("reviewers") or [])
+        ],
     }
     state["review_status"] = "done"
     state["review_error"] = ""
@@ -3796,7 +3802,8 @@ def _ar_spawn_children(
                 custom_direction=str(state.get("custom_direction") or ""),
                 max_rounds=state.get("max_rounds", ar.DEFAULT_MAX_ROUNDS),
                 author_model=(parent.interview_model if parent else ""),
-                reviewer_model=_ar_headless_model(parent),
+                reviewer_model=ar.CURSOR_REVIEWER_PANEL,
+                reviewer_models=ar.CURSOR_REVIEWER_MODELS,
             )
             paper_state["paper_dir"] = str(paper_dir)
             ar.write_ar_state(root, child.slug, paper_state)
@@ -4066,7 +4073,6 @@ class _ARLoopDriver:
     def _close_round(self, state: dict[str, Any], n: int, note: Path) -> None:
         self._note(f"round {n} author finished - building and reviewing")
         build = self._build()
-        author_text = _ar_read_text(note)
 
         state = self._state()
         rec = ar.ensure_round(state, n)
@@ -4077,18 +4083,13 @@ class _ARLoopDriver:
         }
         self._save(state)
 
-        reviewer_model = str(state.get("reviewer_model") or "") or agent_default_model(
-            AGENT_CLAUDE
-        )
         result = ar.run_reviewer(
             self._paper_dir(),
             ar.ar_skill_text(ar.SKILL_REVIEWER),
             venue=str(state.get("venue") or ar.DEFAULT_VENUE),
-            idea=state.get("idea") or {},
             round_n=n,
-            author_note=author_text,
             build=build,
-            model=reviewer_model,
+            models=ar.CURSOR_REVIEWER_MODELS,
             on_line=_ar_logger(self.project_root, self.slug, ar.JOB_REVIEW),
         )
         state = self._state()
@@ -4112,10 +4113,19 @@ class _ARLoopDriver:
 
         rec["review"] = {
             "created_at": _iso_now(),
-            "model": reviewer_model,
+            "model": ar.CURSOR_REVIEWER_PANEL,
+            "models": result.get("models") or list(ar.CURSOR_REVIEWER_MODELS),
             "path": str(review_path),
             "scores": result.get("scores") or {},
             "headline": result.get("headline") or "",
+            "input_pdf": result.get("input_pdf") or str(self._paper_dir() / "main.pdf"),
+            "reviewers": [
+                {
+                    key: item.get(key)
+                    for key in ("model", "scores", "headline", "duration_seconds")
+                }
+                for item in (result.get("reviewers") or [])
+            ],
         }
         rec.pop("review_error", None)
         self._save(state)
@@ -4626,14 +4636,8 @@ def make_handler(
                     return {"ok": False, "error": err}, 400
                 if str(state.get("review_status")) == "running":
                     return {"ok": True, "status": "running"}, 202
-                meta = read_meta(root, slug)
-                model = (
-                    str(body.get("model", "")).strip()
-                    or str(state.get("reviewer_model") or "")
-                    or _ar_headless_model(meta)
-                )
                 ar.update_ar_state(root, slug, review_status="running", review_error="")
-                _ar_run_async(_ar_review_job, root, slug, model)
+                _ar_run_async(_ar_review_job, root, slug)
                 return {"ok": True, "status": "running"}, 202
 
             if action == "submission":

--- a/tests/test_ar_task.py
+++ b/tests/test_ar_task.py
@@ -317,6 +317,111 @@ def test_review_headline() -> None:
     assert "borderline" in headline
 
 
+def test_paper_state_defaults_to_cursor_reviewer_panel() -> None:
+    state = ar.new_paper_state(parent_slug="p", idea={"title": "T"})
+    assert state["reviewer_models"] == list(ar.CURSOR_REVIEWER_MODELS)
+    assert ar.CURSOR_REVIEWER_MODELS == (
+        "gpt-5.6-sol-max",
+        "claude-fable-5-thinking-max",
+        "cursor-grok-4.5-high",
+    )
+
+
+def test_cursor_reviewer_panel_reads_only_isolated_pdf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paper = tmp_path / "paper"
+    paper.mkdir()
+    pdf = paper / "main.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n% compiled artifact under test\n")
+    (paper / "main.tex").write_text("LATEX_SECRET_MUST_NOT_LEAK", encoding="utf-8")
+
+    ratings = {
+        "gpt-5.6-sol-max": (4, "weak reject"),
+        "claude-fable-5-thinking-max": (6, "borderline"),
+        "cursor-grok-4.5-high": (8, "weak accept"),
+    }
+    review_commands: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["agent", "models"]:
+            listing = "Available models\n" + "\n".join(
+                f"{model} - test model" for model in ar.CURSOR_REVIEWER_MODELS
+            )
+            return ar.subprocess.CompletedProcess(cmd, 0, stdout=listing, stderr="")
+
+        review_commands.append(cmd)
+        assert cmd[0:2] == ["agent", "--print"]
+        assert cmd[cmd.index("--mode") + 1] == "ask"
+        assert cmd[cmd.index("--output-format") + 1] == "json"
+        assert "--trust" in cmd
+        assert "--force" not in cmd
+        assert "--yolo" not in cmd
+
+        model = cmd[cmd.index("--model") + 1]
+        workspace = Path(cmd[cmd.index("--workspace") + 1])
+        assert (workspace / "submission.pdf").read_bytes() == pdf.read_bytes()
+        assert not (workspace / "main.tex").exists()
+        prompt = cmd[-1]
+        assert str(workspace / "submission.pdf") in prompt
+        assert "LATEX_SECRET_MUST_NOT_LEAK" not in prompt
+        assert "LaTeX sources of the submission follow" not in prompt
+
+        rating, recommendation = ratings[model]
+        review = SAMPLE_REVIEW.replace("Rating: 4", f"Rating: {rating}").replace(
+            "Recommendation: weak reject",
+            f"Recommendation: {recommendation}",
+        )
+        payload = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": review,
+        }
+        return ar.subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(payload), stderr=""
+        )
+
+    monkeypatch.setattr(ar.subprocess, "run", fake_run)
+    result = ar.run_reviewer(
+        paper,
+        "# reviewer methodology",
+        venue="iclr",
+        round_n=3,
+        build={"ok": True, "clean": True, "pdf": str(pdf)},
+    )
+
+    assert result["ok"] is True
+    assert {cmd[cmd.index("--model") + 1] for cmd in review_commands} == set(
+        ar.CURSOR_REVIEWER_MODELS
+    )
+    assert len(review_commands) == 3
+    assert result["models"] == list(ar.CURSOR_REVIEWER_MODELS)
+    assert result["scores"]["rating"] == 6
+    assert result["scores"]["recommendation"] == "borderline"
+    assert result["headline"].startswith("3 reviewers")
+    assert result["input_pdf"] == str(pdf)
+    for model in ar.CURSOR_REVIEWER_MODELS:
+        assert f"# Reviewer: `{model}`" in result["review"]
+
+
+def test_cursor_reviewer_refuses_missing_compiled_pdf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def should_not_run(*args, **kwargs):
+        raise AssertionError("Cursor CLI must not run without a compiled PDF")
+
+    monkeypatch.setattr(ar.subprocess, "run", should_not_run)
+    result = ar.run_reviewer(
+        tmp_path,
+        "# reviewer methodology",
+        build={"ok": False, "error": "latexmk failed"},
+    )
+    assert result["ok"] is False
+    assert "compiled PDF" in result["error"]
+    assert "latexmk failed" in result["error"]
+
+
 # --- gates and rounds -------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- replace the single Claude/LaTeX review with three independent maximum-reasoning Cursor reviewers
- isolate the compiled PDF as the only paper artifact and preserve both per-model and deterministic panel scores
- update the reviewer rubric, AR state metadata, documentation, and regression coverage

## Test plan
- [x] `uv run --extra dev pytest tests/test_ar_task.py -q` — 62 passed, 1 skipped
- [x] `uv run --with pyyaml --extra dev pytest -q` — 192 passed, 1 skipped
- [x] real compiled-PDF sanity run through GPT-5.6 Sol Max, Fable 5 Max Thinking, and Cursor Grok 4.5 High


Made with [Cursor](https://cursor.com)