### PR TITLE
Require submission-ready papers before review

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,11 @@ Each of those is a **paper** task, and it walks a fixed pipeline:
 3. **Rounds** — by default ten of them. The author agent works in the task's tmux
    pane (revising the paper, running experiments locally in the worktree) and
    signals the end of its turn by writing `rounds/round-NN/author.md`. Loom then
-   compiles the PDF and runs three independent Cursor reviewers headlessly:
+   compiles the PDF and applies a hard readiness gate: no TODO/placeholder
+   markers, missing figures, unresolved citations/references, incomplete core
+   sections, build errors or visible `??` may remain. A blocked paper goes back
+   to the author in the same round with the exact failed checks. Only a complete
+   submission runs three independent Cursor reviewers headlessly:
    `gpt-5.6-sol-max`, `claude-fable-5-thinking-max`, and
    `cursor-grok-4.5-high`. Each reviewer sees an isolated workspace containing
    only the compiled PDF (never the LaTeX source); their reports and

--- a/loom/ar_task.py
+++ b/loom/ar_task.py
@@ -33,6 +33,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
+from pypdf import PdfReader
+
 from loom.paths import bundled_skills_path, paper_templates_dir
 from loom.rud_task import WORK_SUBDIR, task_root, task_worktree_path
 
@@ -1524,6 +1526,7 @@ def run_reviewer(
     round_n: int = 1,
     author_note: str = "",
     build: dict[str, Any] | None = None,
+    readiness: dict[str, Any] | None = None,
     models: list[str] | tuple[str, ...] | None = None,
     timeout: int = 900,
     on_line: Any = None,
@@ -1541,6 +1544,19 @@ def run_reviewer(
     if not build.get("ok") or not pdf.is_file():
         error = str(build.get("error") or f"compiled PDF not found at {pdf}")
         return {"ok": False, "error": f"cannot review without a compiled PDF: {error}"}
+
+    gate = readiness or review_readiness(paper_dir, venue=venue, build=build)
+    if not gate.get("ready"):
+        failed = ", ".join(
+            str(item.get("label") or "readiness check")
+            for item in (gate.get("failed") or [])
+        )
+        return {
+            "ok": False,
+            "error": "review readiness gate blocked the reviewer panel"
+            + (f": {failed}" if failed else ""),
+            "readiness": gate,
+        }
 
     selected = tuple(models or CURSOR_REVIEWER_MODELS)
     if selected != CURSOR_REVIEWER_MODELS:
@@ -1892,16 +1908,48 @@ def extract_paper_fields(paper_dir: Path) -> dict[str, Any]:
     }
 
 
-def count_placeholder_markers(paper_dir: Path) -> int:
-    """Unfilled \\ARTODO / \\ARnum / \\ARfig slots left in the paper body."""
-    total = 0
-    sections = paper_dir / "sections"
-    files = list(sections.glob("*.tex")) if sections.is_dir() else []
-    for path in files:
+def _active_tex(text: str) -> str:
+    """Drop LaTeX comments while preserving line numbers for diagnostics."""
+    return re.sub(r"(?<!\\)%.*$", "", text or "", flags=re.MULTILINE)
+
+
+def _paper_tex_sources(paper_dir: Path) -> list[Path]:
+    """Authored TeX inputs, excluding the file that defines AR markers."""
+    if not paper_dir.is_dir():
+        return []
+    return [
+        path
+        for path in sorted(paper_dir.rglob("*.tex"))
+        if path.name != "ar_macros.tex"
+    ]
+
+
+def _source_findings(
+    paper_dir: Path, pattern: re.Pattern[str], limit: int = 12
+) -> list[str]:
+    findings: list[str] = []
+    for path in _paper_tex_sources(paper_dir):
         try:
-            total += len(_MARKER_RE.findall(path.read_text(encoding="utf-8", errors="replace")))
+            text = _active_tex(path.read_text(encoding="utf-8", errors="replace"))
         except OSError:
             continue
+        for match in pattern.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            findings.append(f"{path.relative_to(paper_dir)}:{line} ({match.group(0)})")
+            if len(findings) >= limit:
+                return findings
+    return findings
+
+
+def count_placeholder_markers(paper_dir: Path) -> int:
+    """Active ``\\ARTODO`` / ``\\ARnum`` / ``\\ARfig`` uses in paper sources."""
+    total = 0
+    for path in _paper_tex_sources(paper_dir):
+        try:
+            text = _active_tex(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        total += len(_MARKER_RE.findall(text))
     return total
 
 
@@ -1909,13 +1957,9 @@ def pdf_page_count(pdf: Path) -> int | None:
     if not pdf.is_file():
         return None
     try:
-        proc = subprocess.run(
-            ["pdfinfo", str(pdf)], capture_output=True, text=True, timeout=30
-        )
-    except (OSError, subprocess.TimeoutExpired):
+        return len(PdfReader(str(pdf), strict=False).pages)
+    except Exception:  # noqa: BLE001 - malformed third-party PDF input
         return None
-    match = re.search(r"^Pages:\s+(\d+)", proc.stdout or "", re.MULTILINE)
-    return int(match.group(1)) if match else None
 
 
 def _has_real_results(paper_dir: Path) -> bool:
@@ -1944,6 +1988,257 @@ def _bib_entry_count(paper_dir: Path) -> int:
 
 # The three entries the template ships so the bibliography compiles from day one.
 SEED_BIB_ENTRIES = 3
+
+
+_TEXT_PLACEHOLDER_RE = re.compile(r"\b(?:TODO|TBD|FIXME|XXX)\b", re.IGNORECASE)
+_QUESTION_PLACEHOLDER_RE = re.compile(r"\?{2,}")
+_INCLUDEGRAPHICS_RE = re.compile(
+    r"\\includegraphics\s*(?:\[[^\]]*\])?\s*\{([^{}]+)\}",
+    re.IGNORECASE,
+)
+_GRAPHIC_EXTENSIONS = (".pdf", ".png", ".jpg", ".jpeg", ".eps")
+_REQUIRED_SECTIONS = (
+    "00_abstract.tex",
+    "01_introduction.tex",
+    "02_related_work.tex",
+    "03_method.tex",
+    "04_experiments.tex",
+    "05_conclusion.tex",
+)
+_LATEX_BLOCKING_WARNING_RE = re.compile(
+    r"(undefined references?|undefined citations?|"
+    r"(?:Citation|Reference)\s+.+?\s+undefined|"
+    r"Rerun to get cross-references right|"
+    r"Label\(s\) may have changed|multiply defined)",
+    re.IGNORECASE,
+)
+
+
+def _missing_graphics(paper_dir: Path) -> list[str]:
+    missing: list[str] = []
+    seen: set[str] = set()
+    for source in _paper_tex_sources(paper_dir):
+        try:
+            text = _active_tex(source.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        for match in _INCLUDEGRAPHICS_RE.finditer(text):
+            raw = match.group(1).strip()
+            if raw in seen:
+                continue
+            seen.add(raw)
+            target = Path(raw)
+            roots = (paper_dir, source.parent)
+            candidates: list[Path] = []
+            for root in roots:
+                base = target if target.is_absolute() else root / target
+                if target.suffix:
+                    candidates.append(base)
+                else:
+                    candidates.extend(base.with_suffix(ext) for ext in _GRAPHIC_EXTENSIONS)
+            if not any(path.is_file() for path in candidates):
+                missing.append(raw)
+    return missing
+
+
+def _pdf_text(pdf: Path, timeout: int = 60) -> dict[str, Any]:
+    """Extract the rendered PDF text so visible placeholders cannot hide."""
+    del timeout  # Kept for compatibility with the previous subprocess helper.
+    try:
+        reader = PdfReader(str(pdf), strict=False)
+        text = "\n\f\n".join((page.extract_text() or "") for page in reader.pages)
+    except Exception as exc:  # noqa: BLE001 - malformed third-party PDF input
+        return {"ok": False, "error": f"could not inspect rendered PDF: {exc}"}
+    return {"ok": True, "text": text}
+
+
+def _latex_log(paper_dir: Path, build: dict[str, Any]) -> str:
+    try:
+        return (paper_dir / "main.log").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return str(build.get("log") or "")
+
+
+def review_readiness(
+    paper_dir: Path,
+    *,
+    venue: str = DEFAULT_VENUE,
+    build: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Hard gate before a paper may consume a reviewer turn.
+
+    This deliberately checks submission completeness rather than research
+    quality. A passing paper is compiled, fully rendered, free of placeholders
+    and unresolved references, and contains real results; only the reviewer
+    decides whether that complete submission is scientifically good.
+    """
+    build = build or {}
+    entry = venue_entry(venue)
+    pdf_value = str(build.get("pdf") or "").strip()
+    pdf = Path(pdf_value) if pdf_value else paper_dir / "main.pdf"
+    checks: list[dict[str, Any]] = []
+
+    def check(ok: bool, label: str, detail: str = "") -> None:
+        checks.append({"ok": bool(ok), "label": label, "detail": detail})
+
+    pdf_exists = pdf.is_file()
+    check(
+        bool(build.get("ok")) and pdf_exists,
+        "Compiled PDF exists",
+        str(pdf) if pdf_exists else str(build.get("error") or f"missing {pdf}"),
+    )
+    check(
+        bool(build.get("clean")),
+        "LaTeX build is clean",
+        "latexmk exited 0" if build.get("clean") else "fix every LaTeX build error",
+    )
+
+    marker_locations = _source_findings(paper_dir, _MARKER_RE)
+    marker_count = count_placeholder_markers(paper_dir)
+    check(
+        marker_count == 0,
+        "No AR placeholders remain",
+        "none"
+        if marker_count == 0
+        else f"{marker_count} marker(s): " + ", ".join(marker_locations),
+    )
+
+    text_placeholders = _source_findings(paper_dir, _TEXT_PLACEHOLDER_RE)
+    check(
+        not text_placeholders,
+        "No TODO/TBD/FIXME/XXX text remains",
+        "none" if not text_placeholders else ", ".join(text_placeholders),
+    )
+    question_placeholders = _source_findings(paper_dir, _QUESTION_PLACEHOLDER_RE)
+    check(
+        not question_placeholders,
+        "No unresolved ?? markers remain in sources",
+        "none" if not question_placeholders else ", ".join(question_placeholders),
+    )
+
+    incomplete_sections: list[str] = []
+    sections = paper_dir / "sections"
+    for name in _REQUIRED_SECTIONS:
+        path = sections / name
+        try:
+            active = _active_tex(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            incomplete_sections.append(f"{name} missing")
+            continue
+        if len(_delatex(active)) < 40:
+            incomplete_sections.append(f"{name} is empty or too short")
+    check(
+        not incomplete_sections,
+        "All core paper sections are substantive",
+        "complete" if not incomplete_sections else "; ".join(incomplete_sections),
+    )
+
+    fields = extract_paper_fields(paper_dir)
+    check(
+        bool(fields["title"]) and len(fields["title"]) <= MAX_TITLE_CHARS,
+        "Title is written and within length",
+        fields["title"] or "no paper title found",
+    )
+    abstract = str(fields["abstract"] or "")
+    check(
+        bool(abstract)
+        and fields["abstract_markers"] == 0
+        and len(abstract) <= MAX_ABSTRACT_CHARS,
+        "Abstract is complete",
+        f"{len(abstract)} chars, {fields['abstract_markers']} marker(s)",
+    )
+    check(
+        _has_real_results(paper_dir),
+        "Experiments contain a real table or figure",
+        "found" if _has_real_results(paper_dir) else "add measured results",
+    )
+    bib = _bib_entry_count(paper_dir)
+    check(
+        bib > SEED_BIB_ENTRIES,
+        "Bibliography goes beyond template seeds",
+        f"{bib} entries",
+    )
+
+    missing_graphics = _missing_graphics(paper_dir)
+    check(
+        not missing_graphics,
+        "Every referenced figure file exists",
+        "all present" if not missing_graphics else "missing: " + ", ".join(missing_graphics),
+    )
+
+    warnings = _LATEX_BLOCKING_WARNING_RE.findall(_latex_log(paper_dir, build))
+    check(
+        not warnings,
+        "No unresolved citations, references, or labels",
+        "none" if not warnings else ", ".join(dict.fromkeys(warnings)),
+    )
+
+    pages = pdf_page_count(pdf) if pdf_exists else None
+    page_limit = int(entry.get("page_limit") or 0)
+    page_ok = pages is not None and (not page_limit or pages <= page_limit + 2)
+    check(
+        page_ok,
+        f"PDF page count is inspectable and within {entry['label']} allowance",
+        (
+            f"{pages} pages (main-text limit {page_limit}, +2 allowance for references)"
+            if pages is not None
+            else "pdfinfo could not read the PDF"
+        ),
+    )
+
+    rendered = _pdf_text(pdf) if pdf_exists else {"ok": False, "error": "PDF missing"}
+    if rendered.get("ok"):
+        pdf_text = str(rendered.get("text") or "")
+        visible = []
+        if _QUESTION_PLACEHOLDER_RE.search(pdf_text):
+            visible.append("??")
+        for match in _TEXT_PLACEHOLDER_RE.finditer(pdf_text):
+            token = match.group(0).upper()
+            if token not in visible:
+                visible.append(token)
+        if "FIGURE PLACEHOLDER" in pdf_text.upper():
+            visible.append("FIGURE PLACEHOLDER")
+        check(
+            not visible,
+            "Rendered PDF has no visible placeholders or question marks",
+            "none" if not visible else ", ".join(visible),
+        )
+    else:
+        check(
+            False,
+            "Rendered PDF can be inspected for visible placeholders",
+            str(rendered.get("error") or "PDF text extraction failed"),
+        )
+
+    return {
+        "ready": all(item["ok"] for item in checks),
+        "checks": checks,
+        "failed": [item for item in checks if not item["ok"]],
+        "pdf": str(pdf),
+        "venue": str(entry.get("id") or venue),
+        "checked_at": _now_iso(),
+    }
+
+
+def review_readiness_markdown(result: dict[str, Any]) -> str:
+    status = "PASS — reviewer may run" if result.get("ready") else "BLOCKED — return to author"
+    lines = [
+        "# Review Readiness Gate",
+        "",
+        f"**Status:** {status}",
+        f"**Checked:** {result.get('checked_at', '')}",
+        f"**PDF:** `{result.get('pdf', '')}`",
+        "",
+        "## Checks",
+    ]
+    for item in result.get("checks") or []:
+        mark = "x" if item.get("ok") else " "
+        detail = str(item.get("detail") or "").strip()
+        lines.append(
+            f"- [{mark}] **{item.get('label', 'check')}**"
+            + (f" — {detail}" if detail else "")
+        )
+    return "\n".join(lines).strip() + "\n"
 
 
 def build_submission(
@@ -2229,11 +2524,88 @@ The idea this paper must establish:
 Run the experiments first, then fold the real numbers into the paper, then
 rebuild the PDF. Never write a number an experiment did not produce.
 
+This is a hard review-readiness gate: do not write the completion note until
+the paper is a complete, ready-to-submit artifact. Every \\ARTODO, \\ARnum,
+\\ARfig, TODO/TBD/FIXME/XXX, unresolved ??, missing figure, undefined
+citation/reference, build error, and empty core section must be gone from both
+the sources and the rendered PDF. The experiments section must contain real
+measured results and the bibliography must go beyond the template seeds.
+
 When the round is finished, write your summary to:
 {note}
 
 Writing that file is how Loom knows the round is over and hands the paper to
-the reviewer, so make it the last thing you do, then stop.
+the deterministic readiness gate. Only a passing gate hands the PDF to the
+reviewers. Make the note the last thing you do, then stop.
+"""
+
+
+def author_readiness_repair_prompt(
+    task_dir: Path,
+    paper_dir: Path,
+    state: dict[str, Any],
+    round_n: int,
+    readiness: dict[str, Any],
+    *,
+    report_path: Path | None = None,
+) -> str:
+    """Return a blocked round to the author with deterministic failures."""
+    venue = venue_entry(str(state.get("venue") or DEFAULT_VENUE)).get("label")
+    note = author_note_path_for(task_dir, round_n)
+    failures = readiness.get("failed") or []
+    failure_lines = "\n".join(
+        f"- {item.get('label', 'check')}: {item.get('detail', '')}"
+        for item in failures
+    ) or "- The gate did not provide details; rerun every readiness check."
+    report = str(report_path) if report_path is not None else "(not written)"
+    return f"""You are still the author of Loom AR paper ROUND {round_n}.
+
+The reviewer panel was NOT called. The deterministic Review Readiness Gate
+blocked this paper because it is not yet a complete, ready-to-submit {venue}
+submission.
+
+Task directory:
+{task_dir}
+
+Paper directory:
+{paper_dir}
+
+Idea this paper must establish:
+{idea_summary(state.get("idea") or {})}
+
+Full gate report:
+{report}
+
+Failures that must all be fixed:
+{failure_lines}
+
+Continue the SAME round. Follow the AR author methodology exactly:
+{ar_skill_text(SKILL_AUTHOR) or "(AR author skill missing)"}
+
+Before signalling completion again, make the whole submission complete:
+
+1. Replace every active \\ARTODO, \\ARnum and \\ARfig with finished prose,
+   measured numbers and real generated figures.
+2. Remove every TODO/TBD/FIXME/XXX and unresolved ?? marker from both the
+   source and rendered PDF. Ordinary question-mark punctuation is allowed;
+   unresolved double-question-mark placeholders are not.
+3. Finish every core section: abstract, introduction, related work, method,
+   experiments and conclusion.
+4. Include real measured results, required baselines, ablations, analysis,
+   seeds/variance where applicable, and cost measurements.
+5. Ensure every \\includegraphics target exists and every figure/table is
+   readable in the compiled PDF.
+6. Resolve every citation, reference and label warning.
+7. Expand the bibliography beyond the three template seed entries.
+8. Run latexmk until it exits cleanly, inspect every PDF page, and stay within
+   the venue page allowance.
+
+Do not ask the reviewers to evaluate unfinished work. When and only when every
+failure above is fixed, write a NEW completion note to:
+{note}
+
+Writing that file is the final action. Loom will rerun the deterministic gate;
+the reviewer panel runs only after it passes.
 """
 
 

--- a/loom/skills/ar/AR-AUTHOR.md
+++ b/loom/skills/ar/AR-AUTHOR.md
@@ -72,8 +72,15 @@ Each round you get the previous round's `review.md`. Work in this order:
    that are now measured, and update the abstract and introduction so the
    claims match what the tables actually show. Claims shrink when results are
    weaker than hoped; that is the correct outcome, not a failure.
-5. **Rebuild the PDF** and fix any LaTeX errors.
-6. **Write `rounds/round-NN/author.md`** and stop. This file is how Loom knows
+5. **Finish the whole submission before review.** Replace every `\ARTODO`,
+   `\ARnum` and `\ARfig`; remove TODO/TBD/FIXME/XXX and unresolved `??`
+   markers; generate every promised figure; finish every core section; resolve
+   every citation/reference; and make every table and figure readable. A
+   reviewer turn is never spent on an unfinished paper.
+6. **Rebuild and inspect the PDF.** Run `latexmk` until it exits cleanly, then
+   inspect every rendered page for visible placeholders, clipping, broken
+   references, unreadable figures and page-limit problems.
+7. **Write `rounds/round-NN/author.md`** and stop. This file is how Loom knows
    the round is over, so it must be the last thing you do.
 
 `author.md` format:
@@ -88,11 +95,20 @@ Each round you get the previous round's `review.md`. Work in this order:
 - <command> -> <result vs baseline> -> <where it landed in the paper>
 
 ## Still open
-- <point you could not address, and what it would take>
+- None. If anything remains open, do not write `author.md`; keep working.
 
 ## Build
 - latexmk: <clean | errors, with the first one>
 ```
+
+`author.md` enters a deterministic Review Readiness Gate before any reviewer is
+called. The gate requires a clean compiled PDF, no active or rendered
+placeholders, substantive core sections, real results, non-template
+bibliography entries, existing figure files, resolved citations/references and
+an inspectable page count within the venue allowance. If it fails, Loom archives
+the completion note, returns the exact failures to you, and keeps you in the
+same round. Fix every failure and write a new `author.md`; never ask reviewers
+to judge work you already know is incomplete.
 
 ## Experiments run locally
 

--- a/loom/web.py
+++ b/loom/web.py
@@ -3722,9 +3722,30 @@ def _ar_review_job(root: Path, slug: str) -> None:
     )
     if not res.get("ok"):
         log(f"failed: {res.get('error')}")
-        ar.update_ar_state(
-            root, slug, review_status="error", review_error=str(res.get("error") or "")
-        )
+        readiness = res.get("readiness")
+        if isinstance(readiness, dict):
+            report_path = ar.round_dir(root, slug, n) / "readiness.md"
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                report_path.write_text(
+                    ar.review_readiness_markdown(readiness), encoding="utf-8"
+                )
+                readiness["report_path"] = str(report_path)
+            except OSError:
+                pass
+            state = ar.read_ar_state(root, slug)
+            rec = ar.ensure_round(state, n)
+            rec["readiness"] = readiness
+            state["review_status"] = "error"
+            state["review_error"] = str(res.get("error") or "")
+            ar.write_ar_state(root, slug, state)
+        else:
+            ar.update_ar_state(
+                root,
+                slug,
+                review_status="error",
+                review_error=str(res.get("error") or ""),
+            )
         return
     path = ar.review_note_path(root, slug, n)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -3995,6 +4016,17 @@ class _ARLoopDriver:
             self._start_round(state, n + 1)
             return
 
+        readiness = rec.get("readiness")
+        if isinstance(readiness, dict) and not readiness.get("ready"):
+            # A failed completion note is archived. Wait for the author to
+            # write a new one after receiving the deterministic failure list.
+            note = ar.author_note_path(self.project_root, self.slug, n)
+            if note.is_file():
+                self._close_round(state, n, note)
+            elif not readiness.get("repair_prompt_sent_at"):
+                self._send_readiness_prompt(state, n)
+            return
+
         # The author's note is the authoritative end-of-round signal, so check
         # it before the prompt bookkeeping: a round driven by hand, or one whose
         # prompt failed to paste and was sent another way, still closes.
@@ -4070,18 +4102,117 @@ class _ARLoopDriver:
         self._save(state)
         self._note(f"round {n} prompt sent to the agent pane")
 
+    def _send_readiness_prompt(self, state: dict[str, Any], n: int) -> None:
+        rec = ar.round_record(state, n) or {}
+        readiness = (
+            rec.get("readiness")
+            if isinstance(rec.get("readiness"), dict)
+            else {}
+        )
+        report_value = str(readiness.get("report_path") or "")
+        prompt = ar.author_readiness_repair_prompt(
+            task_root(self.project_root, self.slug),
+            self._paper_dir(),
+            state,
+            n,
+            readiness,
+            report_path=Path(report_value) if report_value else None,
+        )
+        ok, err = self._paste(prompt)
+        if not ok:
+            self.last_error = err
+            return
+        self.last_error = ""
+        state = self._state()
+        rec = ar.ensure_round(state, n)
+        latest = dict(rec.get("readiness") or {})
+        latest["repair_prompt_sent_at"] = _iso_now()
+        rec["readiness"] = latest
+        self._save(state)
+        self._note(f"round {n} readiness failures returned to the author")
+
     def _close_round(self, state: dict[str, Any], n: int, note: Path) -> None:
-        self._note(f"round {n} author finished - building and reviewing")
+        self._note(f"round {n} author finished - checking submission readiness")
         build = self._build()
 
         state = self._state()
         rec = ar.ensure_round(state, n)
+        readiness = ar.review_readiness(
+            self._paper_dir(),
+            venue=str(state.get("venue") or ar.DEFAULT_VENUE),
+            build=build,
+        )
+        attempts = rec.setdefault("readiness_attempts", [])
+        attempt_n = len(attempts) + 1
+        report_path = (
+            ar.round_dir(self.project_root, self.slug, n)
+            / (
+                "readiness.md"
+                if readiness.get("ready")
+                else f"readiness-attempt-{attempt_n:02d}.md"
+            )
+        )
+        try:
+            report_path.write_text(
+                ar.review_readiness_markdown(readiness), encoding="utf-8"
+            )
+        except OSError as exc:
+            self.last_error = f"could not write readiness report: {exc}"
+            rec["review_error"] = self.last_error
+            self._save(state)
+            self.stop()
+            return
+        readiness["report_path"] = str(report_path)
+
+        if not readiness.get("ready"):
+            attempt_note = (
+                ar.round_dir(self.project_root, self.slug, n)
+                / f"author-attempt-{attempt_n:02d}.md"
+            )
+            summary = _ar_read_head(note)
+            attempts.append(
+                {
+                    "attempt": attempt_n,
+                    "ended_at": _iso_now(),
+                    "note": str(attempt_note),
+                    "summary": summary,
+                    "report": str(report_path),
+                    "failed": readiness.get("failed") or [],
+                }
+            )
+            rec["readiness"] = readiness
+            rec.pop("author", None)
+            rec.pop("review_error", None)
+            self._save(state)
+            # Persist the blocked state before consuming author.md. If Loom
+            # dies between these operations, restart sees the failed gate and
+            # safely rechecks the still-present note instead of wedging.
+            try:
+                note.replace(attempt_note)
+            except OSError as exc:
+                self.last_error = f"could not archive blocked author note: {exc}"
+                state = self._state()
+                rec = ar.ensure_round(state, n)
+                rec["review_error"] = self.last_error
+                self._save(state)
+                self.stop()
+                return
+            self._note(
+                f"round {n} review blocked by {len(readiness.get('failed') or [])} "
+                "readiness check(s)"
+            )
+            self._send_readiness_prompt(self._state(), n)
+            return
+
         rec["author"] = {
             "ended_at": _iso_now(),
             "note": str(note),
             "summary": _ar_read_head(note),
         }
+        rec["readiness"] = readiness
+        rec.pop("review_error", None)
         self._save(state)
+        self._note(f"round {n} readiness passed - starting reviewer panel")
 
         result = ar.run_reviewer(
             self._paper_dir(),
@@ -4089,6 +4220,7 @@ class _ARLoopDriver:
             venue=str(state.get("venue") or ar.DEFAULT_VENUE),
             round_n=n,
             build=build,
+            readiness=readiness,
             models=ar.CURSOR_REVIEWER_MODELS,
             on_line=_ar_logger(self.project_root, self.slug, ar.JOB_REVIEW),
         )

--- a/loom/web_static/app.js
+++ b/loom/web_static/app.js
@@ -4900,6 +4900,15 @@ function renderArRounds(d, state) {
     const label = r.n === 0 ? 'Draft' : `Round ${r.n}`;
     const author = r.author || null;
     const review = r.review || null;
+    const readiness = r.readiness || null;
+    const readinessFailures = readiness && Array.isArray(readiness.failed)
+      ? readiness.failed
+      : [];
+    const readinessHeadline = readiness
+      ? (readiness.ready
+        ? 'readiness passed'
+        : `review blocked: ${readinessFailures.length} readiness check(s) failed`)
+      : '';
     const scores = (review && review.scores) || {};
     const chips = Object.entries(scores)
       .map(([k, v]) => `<span class="ar-score">${escapeHtml(k)} ${escapeHtml(String(v))}</span>`)
@@ -4913,7 +4922,7 @@ function renderArRounds(d, state) {
     return `<li class="ar-round">
       <div class="ar-round__head">
         <strong>${escapeHtml(label)}</strong>
-        <span class="ar-round__headline">${escapeHtml((review && review.headline) || (r.review_error ? `review failed: ${r.review_error}` : ''))}</span>
+        <span class="ar-round__headline">${escapeHtml((review && review.headline) || (r.review_error ? `review failed: ${r.review_error}` : readinessHeadline))}</span>
         ${reviewBtn}
       </div>
       <div class="ar-round__scores">${chips}</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ keywords = ["claude-code", "codex", "cursor", "agent", "tmux", "git-worktree"]
 dependencies = [
     "typer>=0.9.0",
     "rich>=13.0.0",
+    "pypdf>=6.15.0",
 ]
 
 [project.urls]

--- a/tests/test_ar_task.py
+++ b/tests/test_ar_task.py
@@ -389,6 +389,7 @@ def test_cursor_reviewer_panel_reads_only_isolated_pdf(
         venue="iclr",
         round_n=3,
         build={"ok": True, "clean": True, "pdf": str(pdf)},
+        readiness={"ready": True, "failed": []},
     )
 
     assert result["ok"] is True
@@ -420,6 +421,107 @@ def test_cursor_reviewer_refuses_missing_compiled_pdf(
     assert result["ok"] is False
     assert "compiled PDF" in result["error"]
     assert "latexmk failed" in result["error"]
+
+
+def test_cursor_reviewer_refuses_incomplete_paper_before_model_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pdf = tmp_path / "main.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    def should_not_run(*args, **kwargs):
+        raise AssertionError("Cursor models must not run when readiness fails")
+
+    monkeypatch.setattr(ar.subprocess, "run", should_not_run)
+    result = ar.run_reviewer(
+        tmp_path,
+        "# reviewer methodology",
+        build={"ok": True, "clean": True, "pdf": str(pdf)},
+        readiness={
+            "ready": False,
+            "failed": [
+                {
+                    "ok": False,
+                    "label": "No AR placeholders remain",
+                    "detail": "3 markers",
+                }
+            ],
+        },
+    )
+    assert result["ok"] is False
+    assert "readiness gate blocked" in result["error"]
+    assert "No AR placeholders remain" in result["error"]
+
+
+def test_loop_driver_returns_failed_readiness_to_same_round(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from loom.web import _ARLoopDriver
+
+    root = _project(tmp_path)
+    meta = create_task(
+        root, "readiness", "goal", kind=ar.KIND_AR, auto_worktree=False
+    )
+    state = ar.new_paper_state(parent_slug="studio", idea={"title": "T"})
+    state["stage"] = ar.STAGE_LOOP
+    state["round"] = 1
+    ar.ensure_round(state, 1)
+    ar.write_ar_state(root, meta.slug, state)
+    note = ar.author_note_path(root, meta.slug, 1)
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("# Round 1\n\nclaimed complete", encoding="utf-8")
+
+    readiness = {
+        "ready": False,
+        "checks": [
+            {
+                "ok": False,
+                "label": "No AR placeholders remain",
+                "detail": "2 markers",
+            }
+        ],
+        "failed": [
+            {
+                "ok": False,
+                "label": "No AR placeholders remain",
+                "detail": "2 markers",
+            }
+        ],
+        "pdf": str(tmp_path / "main.pdf"),
+        "checked_at": "2026-08-07T00:00:00+00:00",
+    }
+    driver = _ARLoopDriver(object(), root, "project", meta.slug)
+    monkeypatch.setattr(
+        driver,
+        "_build",
+        lambda: {"ok": True, "clean": True, "pdf": str(tmp_path / "main.pdf")},
+    )
+    monkeypatch.setattr(ar, "review_readiness", lambda *args, **kwargs: readiness)
+
+    def reviewer_must_not_run(*args, **kwargs):
+        raise AssertionError("reviewer ran before the readiness gate passed")
+
+    monkeypatch.setattr(ar, "run_reviewer", reviewer_must_not_run)
+    repair_prompts: list[int] = []
+    monkeypatch.setattr(
+        driver,
+        "_send_readiness_prompt",
+        lambda current_state, round_n: repair_prompts.append(round_n),
+    )
+
+    driver._close_round(state, 1, note)
+
+    after = ar.read_ar_state(root, meta.slug)
+    rec = ar.round_record(after, 1)
+    assert rec is not None
+    assert rec["readiness"]["ready"] is False
+    assert rec["review"] is None
+    assert "author" not in rec
+    assert len(rec["readiness_attempts"]) == 1
+    assert Path(rec["readiness_attempts"][0]["note"]).is_file()
+    assert Path(rec["readiness_attempts"][0]["report"]).is_file()
+    assert not note.exists()
+    assert repair_prompts == [1]
 
 
 # --- gates and rounds -------------------------------------------------------
@@ -687,6 +789,143 @@ def test_bib_entry_count(tmp_path: Path) -> None:
     assert ar._bib_entry_count(paper) == ar.SEED_BIB_ENTRIES
 
 
+def _write_ready_paper(tmp_path: Path) -> Path:
+    paper = tmp_path / "paper"
+    ok, msg = ar.seed_paper_skeleton(
+        paper,
+        "iclr",
+        {"title": "A Complete Submission", "metric": "accuracy, latency"},
+    )
+    assert ok, msg
+    sections = {
+        "00_abstract.tex": (
+            "We introduce a concrete method for efficient inference and evaluate "
+            "it against matched baselines. Across repeated measurements, the method "
+            "improves accuracy while preserving latency, with limitations stated."
+        ),
+        "01_introduction.tex": (
+            "\\section{Introduction}\nThis paper studies an important efficiency "
+            "problem, identifies a precise gap, and contributes a reproducible "
+            "method plus controlled empirical evidence."
+        ),
+        "02_related_work.tex": (
+            "\\section{Related Work}\nPrior efficient inference and quantization "
+            "methods provide the closest comparisons. Our contribution differs in "
+            "its mechanism and matched-cost evaluation \\citep{vaswani2017attention}."
+        ),
+        "03_method.tex": (
+            "\\section{Method}\nWe define the transformation, objective, algorithm, "
+            "and assumptions in enough detail to reproduce every operation. The "
+            "runtime overhead is measured rather than asserted."
+        ),
+        "04_experiments.tex": (
+            "\\section{Experiments}\nWe evaluate three seeds against tuned baselines "
+            "using the same data and compute budget. "
+            "\\begin{table}[t]\\caption{Measured results over three seeds.}"
+            "\\begin{tabular}{lc}Baseline & 71.2\\\\Ours & 74.8\\end{tabular}"
+            "\\end{table}\n"
+            "\\begin{figure}[t]\\includegraphics{figures/result}"
+            "\\caption{Measured accuracy and latency.}\\end{figure}\n"
+            "Ablations isolate the proposed mechanism and the analysis reports "
+            "variance, failure cases, memory, and latency."
+        ),
+        "05_conclusion.tex": (
+            "\\section{Conclusion}\nThe measured evidence supports the narrow claim "
+            "that the method improves the tested setting. We state the principal "
+            "scope limitation and the next experiment needed for broader use."
+        ),
+        "06_appendix.tex": (
+            "\\section{Reproducibility}\nThe appendix records exact commands, "
+            "environments, hyperparameters, seeds, negative results, and additional "
+            "breakdowns needed to reproduce the reported measurements."
+        ),
+    }
+    for name, text in sections.items():
+        (paper / "sections" / name).write_text(text, encoding="utf-8")
+    figure = paper / "figures" / "result.pdf"
+    figure.write_bytes(b"%PDF-1.4\n% generated figure\n")
+    with (paper / "main.bib").open("a", encoding="utf-8") as fh:
+        fh.write(
+            "\n@inproceedings{extra2026complete,\n"
+            "  title={A Complete Baseline}, author={A. Author}, year={2026}\n}\n"
+        )
+    (paper / "main.pdf").write_bytes(b"%PDF-1.4\n% complete paper\n")
+    return paper
+
+
+def test_review_readiness_accepts_complete_rendered_paper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paper = _write_ready_paper(tmp_path)
+    monkeypatch.setattr(ar, "pdf_page_count", lambda pdf: 9)
+    monkeypatch.setattr(
+        ar,
+        "_pdf_text",
+        lambda pdf: {
+            "ok": True,
+            "text": "A Complete Submission\nMeasured results and real figures.",
+        },
+    )
+    result = ar.review_readiness(
+        paper,
+        venue="iclr",
+        build={"ok": True, "clean": True, "pdf": str(paper / "main.pdf"), "log": ""},
+    )
+    assert result["ready"] is True
+    assert result["failed"] == []
+    assert all(item["ok"] for item in result["checks"])
+    report = ar.review_readiness_markdown(result)
+    assert "PASS — reviewer may run" in report
+
+
+def test_review_readiness_rejects_fresh_draft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if not ar.venue_is_available("iclr"):
+        pytest.skip("styles not vendored")
+    paper = tmp_path / "paper"
+    ar.seed_paper_skeleton(paper, "iclr", {"title": "Draft"})
+    (paper / "main.pdf").write_bytes(b"%PDF-1.4\n")
+    monkeypatch.setattr(ar, "pdf_page_count", lambda pdf: 7)
+    monkeypatch.setattr(
+        ar,
+        "_pdf_text",
+        lambda pdf: {"ok": True, "text": "TODO: unfinished result ?? FIGURE PLACEHOLDER"},
+    )
+    result = ar.review_readiness(
+        paper,
+        venue="iclr",
+        build={"ok": True, "clean": True, "pdf": str(paper / "main.pdf"), "log": ""},
+    )
+    labels = {item["label"]: item["ok"] for item in result["checks"]}
+    assert result["ready"] is False
+    assert labels["No AR placeholders remain"] is False
+    assert labels["Experiments contain a real table or figure"] is False
+    assert labels["Rendered PDF has no visible placeholders or question marks"] is False
+
+
+def test_review_readiness_rejects_missing_figure_and_question_mark(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paper = _write_ready_paper(tmp_path)
+    (paper / "figures" / "result.pdf").unlink()
+    monkeypatch.setattr(ar, "pdf_page_count", lambda pdf: 9)
+    monkeypatch.setattr(
+        ar,
+        "_pdf_text",
+        lambda pdf: {"ok": True, "text": "Results are still ?? and TBD."},
+    )
+    result = ar.review_readiness(
+        paper,
+        venue="iclr",
+        build={"ok": True, "clean": True, "pdf": str(paper / "main.pdf"), "log": ""},
+    )
+    labels = {item["label"]: item["ok"] for item in result["checks"]}
+    assert result["ready"] is False
+    assert labels["Every referenced figure file exists"] is False
+    assert labels["Rendered PDF has no visible placeholders or question marks"] is False
+
+
 def test_build_submission_flags_an_unfinished_paper(tmp_path: Path) -> None:
     if not ar.venue_is_available("iclr"):
         pytest.skip("styles not vendored")
@@ -794,9 +1033,32 @@ def test_author_prompts_carry_the_contract(tmp_path: Path) -> None:
     assert "Rating: 4" in rnd
     assert "add a baseline" in rnd
     assert str(ar.author_note_path_for(task_dir, 3)) in rnd
+    assert "hard review-readiness gate" in rnd
+    assert "ready-to-submit artifact" in rnd
 
     first = ar.author_round_prompt(task_dir, paper_dir, state, 1)
     assert "no reviewer report yet" in first
+
+    repair = ar.author_readiness_repair_prompt(
+        task_dir,
+        paper_dir,
+        state,
+        3,
+        {
+            "ready": False,
+            "failed": [
+                {
+                    "label": "Every referenced figure file exists",
+                    "detail": "missing: figures/main.pdf",
+                }
+            ],
+        },
+        report_path=task_dir / "rounds" / "round-03" / "readiness-attempt-01.md",
+    )
+    assert "reviewer panel was NOT called" in repair
+    assert "missing: figures/main.pdf" in repair
+    assert "Continue the SAME round" in repair
+    assert str(ar.author_note_path_for(task_dir, 3)) in repair
 
 
 def test_studio_prompt_reflects_mode(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a deterministic readiness gate that requires a clean compiled PDF, complete sections, real results, resolved references, present figures, and no source or rendered placeholders
- archive blocked author attempts and return an exact failure report in the same round without invoking any reviewer model
- expose readiness status in the AR panel and use portable PDF inspection for page/text checks

## Test plan
- [x] `uv run --extra dev pytest tests/test_ar_task.py -q` — 67 passed, 1 skipped
- [x] `uv run --with pyyaml --extra dev pytest -q` — 197 passed, 1 skipped
- [x] `node --check loom/web_static/app.js`
- [x] real incomplete compiled-PDF sanity confirmed six failed checks and zero reviewer dispatches


Made with [Cursor](https://cursor.com)