### PR TITLE
Enforce paper reporting and venue readiness rules

### DIFF
--- a/docs/research-factory/arch.md
+++ b/docs/research-factory/arch.md
@@ -60,7 +60,7 @@ flowchart TB
 ## 技能库（`loom/skills/ar/`）
 
 技能是 Markdown 文件、方法论即代码：改文件即升级所有 Agent，无需改 Python。
-按用途分七类，注入方式各不相同：
+按用途分八类，注入方式各不相同：
 
 **① 角色方法论**（整篇注入对应角色的每个 prompt，`ar_skill_text`）
 
@@ -93,15 +93,21 @@ venue 实源核对），防造假引用混入提交。
 
 **⑤ 通用结果报告与实验溯源**（整篇注入所有 Author prompt）：
 `paper-results-reporting/SKILL.md` — 与投稿 venue 无关；多 seed 结果统一报告为
-均值 ± 样本标准差，禁止从置信区间反推标准差；论文中不暴露 hash、主机名和
-本地路径，完整 provenance 转存到未编入 PDF 的 `EXPERIMENT_DETAILS.md`。
+均值 ± 样本标准差，禁止从置信区间反推标准差，主论文不展示数值区间端点；
+论文中不暴露 hash、主机名和本地路径，完整 provenance 转存到未编入 PDF 的
+`EXPERIMENT_DETAILS.md`。
 
 **⑥ WSDM 投稿规范**（只整篇注入 WSDM Author prompt）：
 `wsdm-submission-readiness/SKILL.md` — ACM 匿名 review 模板、九页技术正文边界、
 Ethical Considerations 与 References 的页界、正文附录整合和
 `appendix-backup.tex` 独立备份。该技能不负责统计口径，也不会注入其他 venue。
 
-**⑦ Rebuttal 域技能**（物理上同在 `skills/ar/` 下，逻辑属 Rebuttal Factory，
+**⑦ WACV 投稿规范**（只整篇注入 WACV Author prompt）：
+`wacv-submission-readiness/SKILL.md` — WACV 匿名 review 模板、track option、
+八页技术正文与第九页 References 边界、独立 supplement、paper ID 与最终
+PDF 验收。R&R 的一页 rebuttal 仍由 delivery 技能负责。
+
+**⑧ Rebuttal 域技能**（物理上同在 `skills/ar/` 下，逻辑属 Rebuttal Factory，
 见 `docs/rebuttal-factory/arch.md`）：`paper-rebuttal/`（回复起草）、
 `paper-rebuttal-delivery/`（终稿交付通用方法论 + `WACV.md` 会议档案）。
 

--- a/docs/research-factory/arch.md
+++ b/docs/research-factory/arch.md
@@ -52,7 +52,7 @@ flowchart TB
 | API | `loom/web.py` 中 `/api/tasks/<slug>/ar*` 系列路由 |
 | 领域逻辑 | `loom/ar_task.py`（状态、挖掘、ideation、readiness、评审面板）|
 | 任务基建 | `loom/rud_task.py`（任务注册、worktree、tmux agent 命令）|
-| 技能 | `loom/skills/ar/`（AR-STUDIO / AR-AUTHOR / AR-REVIEWER / GPU-RESOURCES / figures/*）|
+| 技能 | `loom/skills/ar/`（角色技能 / 通用论文技能 / venue 专用技能 / figures/*）|
 | 实例存储 | `<factory-root>/.RUD/<slug>/`（`ar.json` 状态 + `rounds/` + `work/`）|
 
 同一个 `ar.json` 按 `role` 字段区分两种实体：`studio` 与 `paper`。
@@ -60,7 +60,7 @@ flowchart TB
 ## 技能库（`loom/skills/ar/`）
 
 技能是 Markdown 文件、方法论即代码：改文件即升级所有 Agent，无需改 Python。
-按用途分五类，注入方式各不相同：
+按用途分七类，注入方式各不相同：
 
 **① 角色方法论**（整篇注入对应角色的每个 prompt，`ar_skill_text`）
 
@@ -91,7 +91,17 @@ venue 实源核对），防造假引用混入提交。
 `GPU-RESOURCES.md` — slurm 集群规范：禁止登录节点跑推理、sbatch 模板、
 显存被野进程占用时的防御性 requeue 守卫。
 
-**⑤ Rebuttal 域技能**（物理上同在 `skills/ar/` 下，逻辑属 Rebuttal Factory，
+**⑤ 通用结果报告与实验溯源**（整篇注入所有 Author prompt）：
+`paper-results-reporting/SKILL.md` — 与投稿 venue 无关；多 seed 结果统一报告为
+均值 ± 样本标准差，禁止从置信区间反推标准差；论文中不暴露 hash、主机名和
+本地路径，完整 provenance 转存到未编入 PDF 的 `EXPERIMENT_DETAILS.md`。
+
+**⑥ WSDM 投稿规范**（只整篇注入 WSDM Author prompt）：
+`wsdm-submission-readiness/SKILL.md` — ACM 匿名 review 模板、九页技术正文边界、
+Ethical Considerations 与 References 的页界、正文附录整合和
+`appendix-backup.tex` 独立备份。该技能不负责统计口径，也不会注入其他 venue。
+
+**⑦ Rebuttal 域技能**（物理上同在 `skills/ar/` 下，逻辑属 Rebuttal Factory，
 见 `docs/rebuttal-factory/arch.md`）：`paper-rebuttal/`（回复起草）、
 `paper-rebuttal-delivery/`（终稿交付通用方法论 + `WACV.md` 会议档案）。
 

--- a/loom/ar_task.py
+++ b/loom/ar_task.py
@@ -3580,6 +3580,7 @@ SKILL_GPU = "GPU-RESOURCES.md"
 SKILL_REBUTTAL = "paper-rebuttal/SKILL.md"
 SKILL_RESULTS_REPORTING = "paper-results-reporting/SKILL.md"
 SKILL_WSDM_SUBMISSION = "wsdm-submission-readiness/SKILL.md"
+SKILL_WACV_SUBMISSION = "wacv-submission-readiness/SKILL.md"
 
 
 def ar_skills_dir() -> Path:
@@ -3647,6 +3648,30 @@ def results_reporting_block() -> str:
         "=== Results reporting and provenance - follow this exactly ===\n"
         + text
         + "\n=== end results reporting and provenance ==="
+    )
+
+
+def is_wacv_paper(state: dict[str, Any]) -> bool:
+    """Whether a paper belongs to WACV, including legacy URL-led studios."""
+    markers = (
+        state.get("venue"),
+        state.get("parent_slug"),
+        state.get("venue_url"),
+    )
+    return any("wacv" in str(marker or "").casefold() for marker in markers)
+
+
+def wacv_submission_block(state: dict[str, Any]) -> str:
+    """The WACV-only submission skill, omitted from every other venue."""
+    if not is_wacv_paper(state):
+        return ""
+    text = ar_skill_text(SKILL_WACV_SUBMISSION)
+    if not text:
+        return ""
+    return (
+        "=== WACV submission requirements - follow this exactly ===\n"
+        + text
+        + "\n=== end WACV submission requirements ==="
     )
 
 
@@ -3797,6 +3822,12 @@ ROLE_SKILLS = (
         "Packages anonymous WSDM papers under ACM and nine-page rules.",
         "Injected in full only into WSDM author prompts.",
     ),
+    (
+        SKILL_WACV_SUBMISSION,
+        "Author",
+        "Packages anonymous WACV papers under track and eight-page rules.",
+        "Injected in full only into WACV author prompts.",
+    ),
 )
 
 
@@ -3878,6 +3909,14 @@ def paper_skills_report(
                 "how": "full text, WSDM papers only",
             },
         )
+    elif is_wacv_paper(state):
+        injected.insert(
+            2,
+            {
+                "name": "wacv-submission-readiness",
+                "how": "full text, WACV papers only",
+            },
+        )
     injected += [
         {"name": sk["name"], "how": "figure menu - read on demand"}
         for sk in figure_skills()
@@ -3893,6 +3932,7 @@ def paper_skills_report(
         "paper-rebuttal",
         "paper-results-reporting",
         "wsdm-submission-readiness",
+        "wacv-submission-readiness",
         "checkbib",
     })
     mentions: dict[str, list[int]] = {}
@@ -4028,6 +4068,8 @@ The idea this paper must establish:
 
 {results_reporting_block()}
 
+{wacv_submission_block(state)}
+
 {wsdm_submission_block(state)}
 
 {figure_skills_block()}
@@ -4106,6 +4148,8 @@ The idea this paper must establish:
 === end methodology ===
 
 {results_reporting_block()}
+
+{wacv_submission_block(state)}
 
 {wsdm_submission_block(state)}
 
@@ -4197,6 +4241,8 @@ Continue the SAME round. Follow the AR author methodology exactly:
 {ar_skill_text(SKILL_AUTHOR) or "(AR author skill missing)"}
 
 {results_reporting_block()}
+
+{wacv_submission_block(state)}
 
 {wsdm_submission_block(state)}
 

--- a/loom/ar_task.py
+++ b/loom/ar_task.py
@@ -3578,6 +3578,8 @@ SKILL_AUTHOR = "AR-AUTHOR.md"
 SKILL_REVIEWER = "AR-REVIEWER.md"
 SKILL_GPU = "GPU-RESOURCES.md"
 SKILL_REBUTTAL = "paper-rebuttal/SKILL.md"
+SKILL_RESULTS_REPORTING = "paper-results-reporting/SKILL.md"
+SKILL_WSDM_SUBMISSION = "wsdm-submission-readiness/SKILL.md"
 
 
 def ar_skills_dir() -> Path:
@@ -3634,6 +3636,43 @@ def gpu_resources_block() -> str:
         + text
         + "\n=== end compute resources ==="
     )
+
+
+def results_reporting_block() -> str:
+    """The result-table and provenance skill as it appears in author prompts."""
+    text = ar_skill_text(SKILL_RESULTS_REPORTING)
+    if not text:
+        return ""
+    return (
+        "=== Results reporting and provenance - follow this exactly ===\n"
+        + text
+        + "\n=== end results reporting and provenance ==="
+    )
+
+
+def is_wsdm_paper(state: dict[str, Any]) -> bool:
+    """Whether a paper belongs to WSDM, including legacy URL-led studios."""
+    markers = (
+        state.get("venue"),
+        state.get("parent_slug"),
+        state.get("venue_url"),
+    )
+    return any("wsdm" in str(marker or "").casefold() for marker in markers)
+
+
+def wsdm_submission_block(state: dict[str, Any]) -> str:
+    """The WSDM-only submission skill, omitted from every other venue."""
+    if not is_wsdm_paper(state):
+        return ""
+    text = ar_skill_text(SKILL_WSDM_SUBMISSION)
+    if not text:
+        return ""
+    return (
+        "=== WSDM submission requirements - follow this exactly ===\n"
+        + text
+        + "\n=== end WSDM submission requirements ==="
+    )
+
 
 def figure_skills_block() -> str:
     """The figure-skill menu as it appears in an author prompt."""
@@ -3746,6 +3785,18 @@ ROLE_SKILLS = (
         "Named in every author round prompt; the author reads it before "
         "answering the reviewers.",
     ),
+    (
+        SKILL_RESULTS_REPORTING,
+        "Author",
+        "Standardizes result-table statistics and manuscript-safe provenance.",
+        "Injected in full into every author prompt.",
+    ),
+    (
+        SKILL_WSDM_SUBMISSION,
+        "Author",
+        "Packages anonymous WSDM papers under ACM and nine-page rules.",
+        "Injected in full only into WSDM author prompts.",
+    ),
 )
 
 
@@ -3811,10 +3862,22 @@ def paper_skills_report(
     injected = [
         {"name": "AR-AUTHOR", "how": "full text, every round prompt"},
         {
+            "name": "paper-results-reporting",
+            "how": "full text, every round prompt",
+        },
+        {
             "name": DEFAULT_TEASER_SKILL,
             "how": "figure menu default - the prompt orders proactive use",
         },
     ]
+    if is_wsdm_paper(state):
+        injected.insert(
+            2,
+            {
+                "name": "wsdm-submission-readiness",
+                "how": "full text, WSDM papers only",
+            },
+        )
     injected += [
         {"name": sk["name"], "how": "figure menu - read on demand"}
         for sk in figure_skills()
@@ -3826,7 +3889,12 @@ def paper_skills_report(
 
     # Evidence pass: the author's own notes, round by round.
     names = {sk["name"] for sk in figure_skills()}
-    names.update({"paper-rebuttal", "checkbib"})
+    names.update({
+        "paper-rebuttal",
+        "paper-results-reporting",
+        "wsdm-submission-readiness",
+        "checkbib",
+    })
     mentions: dict[str, list[int]] = {}
     rounds = rounds_root(project_root, slug)
     if rounds.is_dir():
@@ -3958,6 +4026,10 @@ The idea this paper must establish:
 {ar_skill_text(SKILL_AUTHOR) or "(AR author skill missing)"}
 === end methodology ===
 
+{results_reporting_block()}
+
+{wsdm_submission_block(state)}
+
 {figure_skills_block()}
 
 {gpu_resources_block()}
@@ -4032,6 +4104,10 @@ The idea this paper must establish:
 === AR author methodology - follow this exactly ===
 {ar_skill_text(SKILL_AUTHOR) or "(AR author skill missing)"}
 === end methodology ===
+
+{results_reporting_block()}
+
+{wsdm_submission_block(state)}
 
 {figure_skills_block()}
 
@@ -4119,6 +4195,10 @@ Failures that must all be fixed:
 
 Continue the SAME round. Follow the AR author methodology exactly:
 {ar_skill_text(SKILL_AUTHOR) or "(AR author skill missing)"}
+
+{results_reporting_block()}
+
+{wsdm_submission_block(state)}
 
 {gpu_resources_block()}
 

--- a/loom/skills/ar/paper-results-reporting/SKILL.md
+++ b/loom/skills/ar/paper-results-reporting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-results-reporting
-description: Standardize venue-independent, evidence-backed result tables and provenance hygiene. Use for any paper when reporting multi-seed experiments, formatting mean plus-or-minus sample standard deviation, removing machine hashes from manuscripts, or validating statistical tables.
+description: Standardize venue-independent, evidence-backed result tables, provenance hygiene, and final submission-artifact naming. Use for any paper when reporting multi-seed experiments, formatting mean plus-or-minus sample standard deviation, removing machine hashes from manuscripts, naming a final PDF by submission ID, or validating statistical tables.
 ---
 
 # Paper Results Reporting
@@ -12,9 +12,10 @@ traceable without exposing internal artifact metadata. The paper shows the
 scientific result; a separate experiment-details record preserves machine
 provenance.
 
-This skill is venue-independent. It does not define page limits, templates,
-ethical-section placement, appendix policy, or other conference rules. Apply a
-separate venue skill for submission packaging.
+This skill is venue-independent. It defines result reporting, provenance
+hygiene, and the cross-venue final-PDF naming convention. It does not define
+page limits, templates, ethical-section placement, appendix policy, or other
+conference rules. Apply a separate venue skill for venue-specific packaging.
 
 ## Statistical table rule
 
@@ -108,6 +109,28 @@ For each label record:
 
 Removing a hash from the PDF must never destroy provenance.
 
+## Final main-PDF naming
+
+Name every final main-paper artifact:
+
+```text
+main-paper-<submission-ID>.pdf
+```
+
+Replace `<submission-ID>` with the assigned venue ID. This convention applies
+across venues, including WSDM and WACV. It does not prescribe names for
+supplements or internal appendix backups.
+
+- Prefer building directly to the final name, for example with
+  `latexmk -jobname=main-paper-<submission-ID> main.tex`.
+- If a toolchain must first emit `main.pdf`, move the freshly verified artifact
+  to the final name and delete `main.pdf`; never leave both files.
+- Update `.gitignore`, READMEs, submission manifests, upload instructions, and
+  automation that still refers to `main.pdf`.
+- Recompute recorded size and checksum values after the final build or rename.
+- Reject a package when the expected ID-specific PDF is missing, when a stale
+  `main.pdf` remains, or when the PDF predates source changes.
+
 ## Batch-paper workflow
 
 When several papers need the same polish:
@@ -135,6 +158,8 @@ Before declaring a paper ready:
 - scan rendered text for hexadecimal hashes, private paths, hosts, identity
   leaks, stale CI descriptions, and placeholders, including abbreviated
   7--12-character commit IDs in reproducibility sections;
+- confirm the final artifact is `main-paper-<submission-ID>.pdf`, contains the
+  correct assigned ID, and has no sibling legacy `main.pdf`;
 - compile from source and reject undefined references/citations or overfull
   table content;
 - visually inspect every table for clipping, overlap, and unreadable type.

--- a/loom/skills/ar/paper-results-reporting/SKILL.md
+++ b/loom/skills/ar/paper-results-reporting/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: paper-results-reporting
+description: Standardize venue-independent, evidence-backed result tables and provenance hygiene. Use for any paper when reporting multi-seed experiments, formatting mean plus-or-minus sample standard deviation, removing machine hashes from manuscripts, or validating statistical tables.
+---
+
+# Paper Results Reporting
+
+## Objective
+
+Make every manuscript-facing result readable, statistically defined, and
+traceable without exposing internal artifact metadata. The paper shows the
+scientific result; a separate experiment-details record preserves machine
+provenance.
+
+This skill is venue-independent. It does not define page limits, templates,
+ethical-section placement, appendix policy, or other conference rules. Apply a
+separate venue skill for submission packaging.
+
+## Statistical table rule
+
+For stochastic experimental measurements, report:
+
+```text
+mean ± sample standard deviation
+```
+
+The replicate unit must be the independent final training seed or independent
+final run. First aggregate evaluation examples within each replicate, then
+compute the sample standard deviation across replicate-level values:
+
+```python
+from statistics import stdev
+
+mean = sum(per_seed) / len(per_seed)
+sd = stdev(per_seed)  # denominator n - 1
+```
+
+Every affected caption states `mean ± sample SD over N independent seeds`
+(or runs) and names a different replicate unit when applicable.
+
+### Hard constraints
+
+- Read the actual per-seed/per-run values from raw results or a
+  completion-verified aggregate.
+- Never infer a standard deviation from confidence-interval endpoints.
+- Never invent dispersion or silently substitute standard error.
+- With fewer than two independent replicates, do not print a fake `± 0`.
+  Run another replicate or report the scalar and disclose the limitation.
+- Preserve failed and censored runs according to the frozen protocol.
+- Do not mix runs, configurations, checkpoints, or aggregate revisions.
+- Round only for display; compute from full-precision replicate values.
+
+### Values that do not receive a standard deviation
+
+Do not append `±` to deterministic metadata such as dataset size, parameter
+count, beam width, budget, fixed hyperparameters, theoretical constants, or
+event counts. A genuinely seed-independent exact quantity may be shown as
+`± 0.00` only when that convention is scientifically useful and the caption
+explicitly says why it is zero.
+
+Mean ± SD is descriptive run-to-run variability, not an inferential confidence
+interval. Confidence intervals may remain in prose or figures for inference,
+provided the manuscript does not describe an SD table as a CI table.
+
+## Reproducible export
+
+1. Identify the unique aggregate and completion manifest behind each table.
+2. Add mean and sample-SD fields or LaTeX macros to the aggregator/exporter.
+3. Regenerate the table source; do not hand-copy numbers into multiple files.
+4. Keep the old CI fields when other claims or figures legitimately use them.
+5. Record the aggregate revision and input artifacts in experiment details.
+
+Recommended LaTeX:
+
+```latex
+\newcommand{\SDcell}[2]{\ensuremath{#1 \mathbin{\pm} #2}}
+```
+
+Use one consistent precision per metric family. A displayed mean and SD should
+normally use the same number of decimal places.
+
+## Provenance belongs outside the rendered paper
+
+Do not expose raw SHA hashes, commit hashes, completion digests, local paths,
+hostnames, or internal run-directory names in manuscript tables, captions, or
+body text, including the reproducibility section. This is a conditional
+double-blind linkage risk, not a claim that hashes are secrets or personal
+data: a reviewer may search an identifier that belongs to a public repository
+and recover the authors' identities. Repository visibility can also change
+during review, so do not make manuscript inclusion depend on whether the
+repository is private today.
+
+Do not print full or abbreviated commit IDs from either internal or third-party
+repositories in an anonymous manuscript. Cite the public implementation and
+name a stable release when available; keep the exact revision in experiment
+details. Replace internal identifiers with human-readable labels such as
+`Run A`, `final seeds 1--5`, or a configuration name.
+
+Preserve the full mapping in an existing experiment-details/provenance file. If
+none exists, create `EXPERIMENT_DETAILS.md` outside the `main.tex` input tree.
+For each label record:
+
+- artifact or run purpose;
+- full hash and hash type;
+- producing configuration and seed set;
+- source path relative to the project;
+- verification or completion-manifest status.
+
+Removing a hash from the PDF must never destroy provenance.
+
+## Batch-paper workflow
+
+When several papers need the same polish:
+
+1. Assign one worker per paper with disjoint directory ownership.
+2. Each worker locates evidence, updates exporters and manuscript source,
+   compiles the PDF, and reports all exceptions.
+3. The coordinating agent performs independent acceptance checks; it does not
+   accept a worker's summary as proof.
+4. Return only the failing paper to its worker, with exact evidence.
+
+Do not let parallel workers edit a shared template or shared generated file.
+
+## Acceptance checks
+
+Before declaring a paper ready:
+
+- enumerate every table appearing in the compiled main PDF;
+- classify each numeric field as stochastic measurement or deterministic
+  metadata;
+- recompute sampled table cells from replicate arrays and compare after
+  rounding;
+- confirm every stochastic result cell uses `mean ± sample SD` and every
+  caption names `N` and the replicate unit;
+- scan rendered text for hexadecimal hashes, private paths, hosts, identity
+  leaks, stale CI descriptions, and placeholders, including abbreviated
+  7--12-character commit IDs in reproducibility sections;
+- compile from source and reject undefined references/citations or overfull
+  table content;
+- visually inspect every table for clipping, overlap, and unreadable type.
+
+Report deterministic fields that intentionally remain scalar. “Every number
+has ±” is not a valid acceptance criterion if it fabricates uncertainty.

--- a/loom/skills/ar/paper-results-reporting/SKILL.md
+++ b/loom/skills/ar/paper-results-reporting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-results-reporting
-description: Standardize venue-independent, evidence-backed result tables, provenance hygiene, and final submission-artifact naming. Use for any paper when reporting multi-seed experiments, formatting mean plus-or-minus sample standard deviation, removing machine hashes from manuscripts, naming a final PDF by submission ID, or validating statistical tables.
+description: Standardize venue-independent, evidence-backed result tables, main-paper interval placement, provenance hygiene, and final submission-artifact naming. Use for any paper when reporting multi-seed experiments, keeping numeric interval endpoints out of the abstract, body, and main tables, formatting mean plus-or-minus sample standard deviation, removing machine hashes from manuscripts, naming a final PDF by submission ID, or validating statistical tables.
 ---
 
 # Paper Results Reporting
@@ -60,15 +60,44 @@ event counts. A genuinely seed-independent exact quantity may be shown as
 explicitly says why it is zero.
 
 Mean ± SD is descriptive run-to-run variability, not an inferential confidence
-interval. Confidence intervals may remain in prose or figures for inference,
-provided the manuscript does not describe an SD table as a CI table.
+interval. It may remain in stochastic main-table cells under this rule, but it
+must never be described as a confidence interval.
+
+## Main-paper interval-placement rule
+
+Apply this rule across venues. In the rendered main paper, do not print numeric
+interval endpoints in the abstract, body prose, tables, captions, or figure
+labels. This includes confidence, credible, percentile-bootstrap, standard-error,
+and min--max intervals written as `[lower, upper]`, `(lower, upper)`, or an
+estimate followed by an endpoint pair.
+
+- Report the point estimate, normally the mean, in the abstract and body prose.
+- In main-paper tables, keep stochastic cells as `mean ± sample SD` when the
+  statistical table rule applies. Sample SD is a dispersion summary, not a pair
+  of interval endpoints. Do not add CI columns or endpoint pairs to those cells.
+- Describe inferential outcomes qualitatively when needed, for example that a
+  comparison remains unresolved or that a paired difference stays positive
+  under resampling, without printing endpoint values.
+- Do not print endpoint values in a main-paper figure callout. Visual error bars
+  or shaded bands may remain only when their caption defines the statistic
+  without giving numeric endpoints.
+- Put full interval methodology, endpoint values, per-replicate records, and
+  additional uncertainty analysis in appendix experiment details. If the venue
+  cannot accept an appendix, preserve them in a separate experiment-details
+  artifact rather than the main PDF.
+- Preserve CI, SD, and SE fields in machine-readable results even when the main
+  paper displays only the permitted summary.
+
+Update the source exporter or figure generator as well as generated artifacts,
+so rebuilding cannot restore forbidden intervals.
 
 ## Reproducible export
 
 1. Identify the unique aggregate and completion manifest behind each table.
 2. Add mean and sample-SD fields or LaTeX macros to the aggregator/exporter.
 3. Regenerate the table source; do not hand-copy numbers into multiple files.
-4. Keep the old CI fields when other claims or figures legitimately use them.
+4. Keep CI fields for appendix experiment details and machine-readable audits,
+   not for numeric endpoint display in the main paper.
 5. Record the aggregate revision and input artifacts in experiment details.
 
 Recommended LaTeX:
@@ -155,6 +184,9 @@ Before declaring a paper ready:
   rounding;
 - confirm every stochastic result cell uses `mean ± sample SD` and every
   caption names `N` and the replicate unit;
+- reject numeric interval endpoints in the main-paper abstract, body prose,
+  tables, captions, and figure labels; verify moved interval details are in an
+  appendix experiment-details section or separate experiment-details artifact;
 - scan rendered text for hexadecimal hashes, private paths, hosts, identity
   leaks, stale CI descriptions, and placeholders, including abbreviated
   7--12-character commit IDs in reproducibility sections;

--- a/loom/skills/ar/wacv-submission-readiness/SKILL.md
+++ b/loom/skills/ar/wacv-submission-readiness/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: wacv-submission-readiness
+description: Prepare and validate anonymous WACV submissions. Use only when the target venue is WACV, especially for the WACV review template, track selection, the eight-page technical-body boundary, separate supplementary material, paper-ID headers, fully packed page eight, and final PDF checks.
+---
+
+# WACV Submission Readiness
+
+## Scope
+
+This is a WACV-only venue skill. Apply `paper-results-reporting` separately for
+venue-independent statistics, interval placement, provenance, and normal
+submission-PDF naming.
+
+Rules and track names can change between cycles. Check the official call and
+author kit before final delivery. For WACV 2027, use the verified project rules
+below unless the current official materials disagree.
+
+## Review template and track
+
+Use the WACV review class on US Letter in anonymous two-column form:
+
+```latex
+\documentclass[10pt,twocolumn,letterpaper]{article}
+\usepackage[review,<track>]{wacv}
+```
+
+Replace `<track>` with the option assigned to the paper:
+
+| Track label | `wacv.sty` option |
+|---|---|
+| Applications | `applications` |
+| Algorithms | `algorithms` |
+| Evaluations & Datasets | `datasets` |
+
+Do not infer the track from the paper topic during the final build. Read the
+frozen submission record or user-approved paper summary, then use the same
+option in `main.tex`, `supplement.tex`, and any WACV rebuttal source.
+
+Set and verify:
+
+```latex
+\def\wacvPaperID{<OpenReview-ID>}
+\def\confName{WACV}
+\def\confYear{2027}
+```
+
+The rendered header, title block, PDF text, source, handoff notes, and manifest
+must all use the current submission ID. A prior-round ID may remain only in an
+explicitly labelled historical record, never in an upload artifact.
+
+## Eight-page technical-body boundary
+
+For this project's WACV workflow:
+
+- The main technical body is exactly eight pages and is packed with useful
+  content through the bottom of page eight.
+- References begin on page nine and do not count toward the eight-page body
+  limit.
+- Do not include an Appendix heading or appendix section in the main PDF.
+- Integrate essential appendix evidence into Method, Experiments, Discussion,
+  or Limitations when it strengthens the main argument.
+- Move remaining appendix material into a separately compilable
+  `supplement.tex` that produces `supplement.pdf`.
+
+Do not pad page eight with repetition, oversized spacing, or decorative
+material. Fill real space with definitions, controls, ablations, limitations,
+implementation details, or evidence needed to evaluate the claims.
+
+Check the technical-body boundary separately from total PDF pages. A main PDF
+with references may have nine or more total pages while still satisfying the
+eight-page body limit.
+
+## Result display
+
+The general `paper-results-reporting` rule applies without exception:
+
+- abstract and body prose report point estimates rather than numeric interval
+  endpoints;
+- main-paper tables may use `mean ± sample SD` but must not contain confidence-
+  interval columns or bracketed endpoint pairs;
+- captions and figure labels do not print interval endpoints;
+- full interval endpoints and additional uncertainty analysis belong in the
+  supplement's experiment-details portion or a separate experiment-details
+  artifact.
+
+Update generators and exporters as well as generated TeX, figures, and PDFs so
+a rebuild cannot restore forbidden interval text.
+
+## Supplement
+
+Build the supplement independently with the same current paper ID, year, track,
+anonymity, title, notation, and result values as the main paper. It may contain:
+
+- appendix experiment details and full uncertainty endpoints;
+- derivations, extended proofs, additional ablations, and per-seed records;
+- implementation details, extended qualitative results, and audit tables.
+
+The main paper must not depend on the supplement for a central claim, and the
+supplement must not expose author identity, private paths, hosts, or searchable
+internal hashes.
+
+## Anonymity and artifact hygiene
+
+- Keep review mode enabled and use anonymous author metadata.
+- Remove acknowledgements, affiliations, emails, personal links, local paths,
+  hostnames, and identifying PDF metadata.
+- Keep commit hashes and machine provenance outside rendered submission PDFs.
+- Remove stale venue names, old paper IDs, placeholder text, and template
+  instructions.
+- Build the normal main artifact as `main-paper-<OpenReview-ID>.pdf`; leave no
+  legacy `main.pdf`, and refresh recorded size and SHA-256 values.
+
+For a Round-1 Revise-and-Resubmit package, also apply `paper-rebuttal` and
+`paper-rebuttal-delivery/WACV.md`. Its frozen delivery policy may require the
+upload names `revised-paper.pdf`, `rebuttal.pdf`, and `supplement.pdf`; that
+explicit package policy overrides the normal main-artifact filename.
+
+## Build and acceptance loop
+
+1. Force-build the main PDF and `supplement.pdf` from their current sources.
+2. Reject LaTeX errors, undefined citations or references, overfull content,
+   clipped floats, overlaps, unreadable tables, and stale generated artifacts.
+3. Confirm the rendered header has the current ID and approved track.
+4. Confirm pages 1--8 are technical content, page eight is substantively full,
+   and References begins on page nine.
+5. Confirm the main PDF has no appendix section and the supplement builds
+   independently.
+6. Scan source, rendered text, and figure pixels for numeric interval endpoints,
+   identity leaks, hashes, private paths, old IDs, and stale track labels.
+7. Visually inspect every main-paper page and every supplementary page.
+8. Recompute manifest sizes and checksums only after the final verified build.
+
+Report the eight-page body count, total main-PDF page count, reference start
+page, supplement page count, track, paper ID, filenames, sizes, and checksums.

--- a/loom/skills/ar/wsdm-submission-readiness/SKILL.md
+++ b/loom/skills/ar/wsdm-submission-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wsdm-submission-readiness
-description: Prepare and validate WSDM submissions in anonymous ACM proceedings format. Use only when the target venue is WSDM, especially for ACM template migration, the nine-page technical-content boundary, Ethical Considerations placement, appendix triage, and final PDF checks.
+description: Prepare and validate WSDM submissions in anonymous ACM proceedings format. Use only when the target venue is WSDM, especially for ACM template migration, the nine-page technical-content boundary, mean-only narrative results, Ethical Considerations placement, appendix triage, and final PDF checks.
 ---
 
 # WSDM Submission Readiness
@@ -33,6 +33,33 @@ site has been updated.
 
 Do not infer compliance from total PDF pages alone. Inspect where the technical
 body ends, where Ethical Considerations begins, and where References begins.
+
+## WSDM result-display policy
+
+Apply `paper-results-reporting` to tables: stochastic table cells remain
+`mean ± sample SD`, with the replicate unit and count defined in the caption.
+Do not remove table dispersion to satisfy this section.
+
+In WSDM narrative prose, report the point estimate (mean) only. This applies to
+every numerical experimental result in the abstract, introduction, method,
+experiments, discussion, limitations, conclusion, captions, and numerical
+callouts embedded in figures.
+
+- Do not write a point estimate followed by bracketed or parenthesized interval
+  endpoints in prose.
+- Do not print `mean ± SD`, `mean ± SE`, or another numeric uncertainty pair
+  as an inline prose result.
+- A caption may define what graphical error bars or shaded bands represent,
+  and a figure may retain those visual uncertainty marks, but its text labels
+  must not print the interval endpoints.
+- Preserve the underlying CI/SD fields in machine-readable results when they
+  remain useful for tables, plots, or audits.
+- Update figure generators and LaTeX exporters, not only generated PDF/PNG
+  files, so a rebuild cannot restore forbidden interval labels.
+
+Before delivery, scan both source and rendered PDF text for estimate-plus-
+interval patterns. Inspect figure pixels when labels are paths or otherwise
+not extractable as text.
 
 ## Laboratory packaging policy
 
@@ -80,7 +107,9 @@ demographic, causal, privacy, or safety evidence was measured.
 
 ## Build and acceptance loop
 
-1. Force-build `main.pdf` from source rather than trusting a stale artifact.
+1. Force-build `main-paper-<CMT-ID>.pdf` from `main.tex` rather than trusting a
+   stale artifact. Follow the general naming skill and leave no legacy
+   `main.pdf`.
 2. Build `appendix-backup.pdf` independently when a backup exists.
 3. Reject LaTeX errors, undefined citations or references, overfull content,
    clipped floats, overlapping text, and visibly unbalanced reference columns.
@@ -88,9 +117,11 @@ demographic, causal, privacy, or safety evidence was measured.
 5. Confirm technical content ends on page nine or earlier.
 6. Confirm Ethical Considerations begins only after the technical boundary and
    References follows it.
-7. Scan the rendered PDF for identity leaks, local paths, internal hashes,
+7. Confirm prose and figure text use point estimates only while stochastic
+   table cells retain `mean ± sample SD`.
+8. Scan the rendered PDF for identity leaks, local paths, internal hashes,
    placeholders, stale venue names, and old template text.
-8. Visually inspect all nine technical pages plus the ethics/reference pages.
+9. Visually inspect all nine technical pages plus the ethics/reference pages.
 
 Report the technical-body page count separately from the total PDF page count.
 An eleven-page PDF is common when pages 1--9 are technical content, page 10 is

--- a/loom/skills/ar/wsdm-submission-readiness/SKILL.md
+++ b/loom/skills/ar/wsdm-submission-readiness/SKILL.md
@@ -36,9 +36,11 @@ body ends, where Ethical Considerations begins, and where References begins.
 
 ## WSDM result-display policy
 
-Apply `paper-results-reporting` to tables: stochastic table cells remain
-`mean ± sample SD`, with the replicate unit and count defined in the caption.
-Do not remove table dispersion to satisfy this section.
+Apply the general `paper-results-reporting` interval-placement rule to the
+abstract, body, tables, captions, and figure labels. Stochastic main-table cells
+remain `mean ± sample SD`, with the replicate unit and count defined in the
+caption, but they must not add confidence-interval columns or endpoint pairs.
+Do not remove table dispersion merely to eliminate interval endpoints.
 
 In WSDM narrative prose, report the point estimate (mean) only. This applies to
 every numerical experimental result in the abstract, introduction, method,
@@ -52,14 +54,16 @@ callouts embedded in figures.
 - A caption may define what graphical error bars or shaded bands represent,
   and a figure may retain those visual uncertainty marks, but its text labels
   must not print the interval endpoints.
-- Preserve the underlying CI/SD fields in machine-readable results when they
-  remain useful for tables, plots, or audits.
+- Preserve the underlying CI/SD fields in machine-readable results and, when
+  scientifically useful, report full endpoints in the experiment-details
+  portion of `appendix-backup.tex`; do not put them in the main WSDM PDF.
 - Update figure generators and LaTeX exporters, not only generated PDF/PNG
   files, so a rebuild cannot restore forbidden interval labels.
 
-Before delivery, scan both source and rendered PDF text for estimate-plus-
-interval patterns. Inspect figure pixels when labels are paths or otherwise
-not extractable as text.
+Before delivery, scan both main source and rendered main-PDF text for
+estimate-plus-interval patterns, including tables. Inspect figure pixels when
+labels are paths or otherwise not extractable as text. Full interval endpoints
+may appear only in appendix experiment details kept outside the main WSDM PDF.
 
 ## Laboratory packaging policy
 
@@ -117,8 +121,9 @@ demographic, causal, privacy, or safety evidence was measured.
 5. Confirm technical content ends on page nine or earlier.
 6. Confirm Ethical Considerations begins only after the technical boundary and
    References follows it.
-7. Confirm prose and figure text use point estimates only while stochastic
-   table cells retain `mean ± sample SD`.
+7. Confirm the abstract, body prose, main tables, captions, and figure labels
+   contain no numeric interval endpoints; stochastic table cells may retain
+   `mean ± sample SD`.
 8. Scan the rendered PDF for identity leaks, local paths, internal hashes,
    placeholders, stale venue names, and old template text.
 9. Visually inspect all nine technical pages plus the ethics/reference pages.

--- a/loom/skills/ar/wsdm-submission-readiness/SKILL.md
+++ b/loom/skills/ar/wsdm-submission-readiness/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: wsdm-submission-readiness
+description: Prepare and validate WSDM submissions in anonymous ACM proceedings format. Use only when the target venue is WSDM, especially for ACM template migration, the nine-page technical-content boundary, Ethical Considerations placement, appendix triage, and final PDF checks.
+---
+
+# WSDM Submission Readiness
+
+## Scope
+
+This is a WSDM-only venue skill. Do not apply its template or page-boundary
+rules to another conference. Use `paper-results-reporting` separately for
+statistical tables and provenance.
+
+Rules can change between WSDM cycles. Check the official call for papers before
+final delivery. For WSDM 2027, use the verified rules below unless the official
+site has been updated.
+
+## WSDM 2027 submission boundary
+
+- Use the ACM proceedings class:
+
+  ```latex
+  \documentclass[sigconf,anonymous,review]{acmart}
+  ```
+
+- Use `ACM-Reference-Format` for the bibliography.
+- The technical paper is at most nine pages, including figures, tables, and
+  any appendix included in the submission PDF.
+- Ethical Considerations and References do not count toward those nine pages.
+- Place the paper-specific Ethical Considerations section immediately after
+  the technical body and before References.
+- Keep the review PDF anonymous and include the assigned CMT submission ID.
+
+Do not infer compliance from total PDF pages alone. Inspect where the technical
+body ends, where Ethical Considerations begins, and where References begins.
+
+## Laboratory packaging policy
+
+For the full-nine-page workflow used by this project:
+
+1. Integrate scientifically necessary appendix material into the relevant
+   Method, Experiments, Discussion, or Limitations section.
+2. Do not leave an `Appendix` heading in the main submission PDF.
+3. Preserve overflow material in an independently compilable
+   `appendix-backup.tex`.
+4. Do not input or include that backup from `main.tex`.
+5. Treat the backup as an archive, not as a conference supplement unless the
+   current WSDM rules explicitly permit one.
+
+Do not pad weak content merely to fill page nine. Use the space for evidence,
+definitions, ablations, limitations, or reproducibility details that improve
+the paper.
+
+## Ethical Considerations
+
+Write a paper-specific section rather than boilerplate. Cover the relevant
+subset of:
+
+- data licensing, consent, privacy, and redistribution;
+- ranking, recommendation, exposure, or allocation harms;
+- model, judge, benchmark, or contamination misinterpretation;
+- misuse and high-stakes deployment boundaries;
+- compute and environmental costs;
+- limitations of the evidence and concrete mitigations.
+
+The section must not introduce unsupported claims or pretend that unavailable
+demographic, causal, privacy, or safety evidence was measured.
+
+## ACM and anonymity checks
+
+- Keep `anonymous,review` enabled.
+- Use anonymous author metadata and remove acknowledgements for review.
+- Remove author names, affiliations, emails, personal paths, hostnames, and
+  identifying PDF metadata.
+- Keep raw hashes and internal artifact identifiers outside the rendered paper;
+  `paper-results-reporting` defines the provenance record.
+- Remove ICLR/NeurIPS/WACV style files, commands, and bibliography styles from
+  the active build.
+- Ensure every figure and table is legible at the ACM two-column print size.
+
+## Build and acceptance loop
+
+1. Force-build `main.pdf` from source rather than trusting a stale artifact.
+2. Build `appendix-backup.pdf` independently when a backup exists.
+3. Reject LaTeX errors, undefined citations or references, overfull content,
+   clipped floats, overlapping text, and visibly unbalanced reference columns.
+4. Confirm the main PDF has no Appendix heading or appendix section.
+5. Confirm technical content ends on page nine or earlier.
+6. Confirm Ethical Considerations begins only after the technical boundary and
+   References follows it.
+7. Scan the rendered PDF for identity leaks, local paths, internal hashes,
+   placeholders, stale venue names, and old template text.
+8. Visually inspect all nine technical pages plus the ethics/reference pages.
+
+Report the technical-body page count separately from the total PDF page count.
+An eleven-page PDF is common when pages 1--9 are technical content, page 10 is
+Ethical Considerations, and page 11 is References, but eleven total pages is
+not itself a rule.

--- a/tests/test_ar_task.py
+++ b/tests/test_ar_task.py
@@ -152,6 +152,21 @@ class TestSkillCatalog:
         assert "no numeric interval endpoints" in body
         assert "appendix experiment details" in body
 
+    def test_lists_the_wacv_submission_skill_separately(self):
+        wacv = next(
+            skill
+            for skill in ar.skill_catalog()
+            if skill["id"] == ar.SKILL_WACV_SUBMISSION
+        )
+        assert wacv["name"] == "wacv-submission-readiness"
+        assert wacv["role"] == "Author"
+        body = ar.skill_body(ar.SKILL_WACV_SUBMISSION)
+        assert "eight-page technical-body boundary" in body
+        assert r"\usepackage[review,<track>]{wacv}" in body
+        assert "fully packed page eight" in body
+        assert "supplement.pdf" in body
+        assert "numeric interval endpoints" in body
+
     def test_body_reads_a_catalogued_skill(self):
         first = ar.skill_catalog()[0]
         assert len(ar.skill_body(first["id"])) > 200
@@ -1595,6 +1610,7 @@ def test_resolve_invitation_prefers_an_open_window(monkeypatch: pytest.MonkeyPat
         ar.SKILL_REVIEWER,
         ar.SKILL_RESULTS_REPORTING,
         ar.SKILL_WSDM_SUBMISSION,
+        ar.SKILL_WACV_SUBMISSION,
     ],
 )
 def test_ar_skills_are_bundled(name: str) -> None:
@@ -1668,6 +1684,7 @@ def test_author_prompts_inject_results_reporting(tmp_path: Path) -> None:
         assert "appendix experiment details" in prompt
         assert "main-paper-<submission-ID>.pdf" in prompt
         assert "WSDM submission requirements" not in prompt
+        assert "WACV submission requirements" not in prompt
 
 
 def test_wsdm_author_prompts_inject_only_the_wsdm_skill(tmp_path: Path) -> None:
@@ -1688,6 +1705,7 @@ def test_wsdm_author_prompts_inject_only_the_wsdm_skill(tmp_path: Path) -> None:
     for prompt in prompts:
         assert "Results reporting and provenance" in prompt
         assert "WSDM submission requirements" in prompt
+        assert "WACV submission requirements" not in prompt
         assert r"\documentclass[sigconf,anonymous,review]{acmart}" in prompt
         assert "appendix-backup.tex" in prompt
         assert "point estimate (mean) only" in prompt
@@ -1698,6 +1716,36 @@ def test_wsdm_author_prompts_inject_only_the_wsdm_skill(tmp_path: Path) -> None:
     non_wsdm = _paper_state()
     assert not ar.is_wsdm_paper(non_wsdm)
     assert ar.wsdm_submission_block(non_wsdm) == ""
+
+
+def test_wacv_author_prompts_inject_only_the_wacv_skill(tmp_path: Path) -> None:
+    state = _paper_state()
+    state["parent_slug"] = "wacv2027"
+    assert ar.is_wacv_paper(state)
+    prompts = (
+        ar.author_draft_prompt(tmp_path, tmp_path / "manuscript", state),
+        ar.author_round_prompt(tmp_path, tmp_path / "manuscript", state, 2),
+        ar.author_readiness_repair_prompt(
+            tmp_path,
+            tmp_path / "manuscript",
+            state,
+            2,
+            {"ready": False, "failed": []},
+        ),
+    )
+    for prompt in prompts:
+        assert "Results reporting and provenance" in prompt
+        assert "WACV submission requirements" in prompt
+        assert "WSDM submission requirements" not in prompt
+        assert r"\usepackage[review,<track>]{wacv}" in prompt
+        assert "exactly eight pages" in prompt
+        assert "supplement.pdf" in prompt
+        assert "numeric interval endpoints" in prompt
+        assert "main-paper-<OpenReview-ID>.pdf" in prompt
+
+    non_wacv = _paper_state()
+    assert not ar.is_wacv_paper(non_wacv)
+    assert ar.wacv_submission_block(non_wacv) == ""
 
 
 def test_ar_skill_text_missing_file() -> None:

--- a/tests/test_ar_task.py
+++ b/tests/test_ar_task.py
@@ -130,9 +130,10 @@ class TestSkillCatalog:
         )
         assert reporting["name"] == "paper-results-reporting"
         assert reporting["role"] == "Author"
-        assert "sample standard deviation" in ar.skill_body(
-            ar.SKILL_RESULTS_REPORTING
-        )
+        body = ar.skill_body(ar.SKILL_RESULTS_REPORTING)
+        assert "sample standard deviation" in body
+        assert "main-paper-<submission-ID>.pdf" in body
+        assert "never leave both files" in body
 
     def test_lists_the_wsdm_submission_skill_separately(self):
         wsdm = next(
@@ -142,9 +143,10 @@ class TestSkillCatalog:
         )
         assert wsdm["name"] == "wsdm-submission-readiness"
         assert wsdm["role"] == "Author"
-        assert "nine-page technical-content boundary" in ar.skill_body(
-            ar.SKILL_WSDM_SUBMISSION
-        )
+        body = ar.skill_body(ar.SKILL_WSDM_SUBMISSION)
+        assert "nine-page technical-content boundary" in body
+        assert "point estimate (mean) only" in body
+        assert "stochastic table cells remain" in body
 
     def test_body_reads_a_catalogued_skill(self):
         first = ar.skill_catalog()[0]
@@ -1658,6 +1660,7 @@ def test_author_prompts_inject_results_reporting(tmp_path: Path) -> None:
         assert "Results reporting and provenance" in prompt
         assert "mean ± sample standard deviation" in prompt
         assert "EXPERIMENT_DETAILS.md" in prompt
+        assert "main-paper-<submission-ID>.pdf" in prompt
         assert "WSDM submission requirements" not in prompt
 
 
@@ -1681,6 +1684,8 @@ def test_wsdm_author_prompts_inject_only_the_wsdm_skill(tmp_path: Path) -> None:
         assert "WSDM submission requirements" in prompt
         assert r"\documentclass[sigconf,anonymous,review]{acmart}" in prompt
         assert "appendix-backup.tex" in prompt
+        assert "point estimate (mean) only" in prompt
+        assert "main-paper-<CMT-ID>.pdf" in prompt
 
     non_wsdm = _paper_state()
     assert not ar.is_wsdm_paper(non_wsdm)

--- a/tests/test_ar_task.py
+++ b/tests/test_ar_task.py
@@ -132,6 +132,8 @@ class TestSkillCatalog:
         assert reporting["role"] == "Author"
         body = ar.skill_body(ar.SKILL_RESULTS_REPORTING)
         assert "sample standard deviation" in body
+        assert "Main-paper interval-placement rule" in body
+        assert "appendix experiment details" in body
         assert "main-paper-<submission-ID>.pdf" in body
         assert "never leave both files" in body
 
@@ -146,7 +148,9 @@ class TestSkillCatalog:
         body = ar.skill_body(ar.SKILL_WSDM_SUBMISSION)
         assert "nine-page technical-content boundary" in body
         assert "point estimate (mean) only" in body
-        assert "stochastic table cells remain" in body
+        assert "Stochastic main-table cells" in body
+        assert "no numeric interval endpoints" in body
+        assert "appendix experiment details" in body
 
     def test_body_reads_a_catalogued_skill(self):
         first = ar.skill_catalog()[0]
@@ -1660,6 +1664,8 @@ def test_author_prompts_inject_results_reporting(tmp_path: Path) -> None:
         assert "Results reporting and provenance" in prompt
         assert "mean ± sample standard deviation" in prompt
         assert "EXPERIMENT_DETAILS.md" in prompt
+        assert "Main-paper interval-placement rule" in prompt
+        assert "appendix experiment details" in prompt
         assert "main-paper-<submission-ID>.pdf" in prompt
         assert "WSDM submission requirements" not in prompt
 
@@ -1685,6 +1691,8 @@ def test_wsdm_author_prompts_inject_only_the_wsdm_skill(tmp_path: Path) -> None:
         assert r"\documentclass[sigconf,anonymous,review]{acmart}" in prompt
         assert "appendix-backup.tex" in prompt
         assert "point estimate (mean) only" in prompt
+        assert "no numeric interval endpoints" in prompt
+        assert "appendix experiment details" in prompt
         assert "main-paper-<CMT-ID>.pdf" in prompt
 
     non_wsdm = _paper_state()

--- a/tests/test_ar_task.py
+++ b/tests/test_ar_task.py
@@ -122,6 +122,30 @@ class TestSkillCatalog:
         assert rebuttal["role"] == "Rebuttal"
         assert "Acceptance-first" in ar.skill_body(ar.SKILL_REBUTTAL)
 
+    def test_lists_the_results_reporting_skill(self):
+        reporting = next(
+            skill
+            for skill in ar.skill_catalog()
+            if skill["id"] == ar.SKILL_RESULTS_REPORTING
+        )
+        assert reporting["name"] == "paper-results-reporting"
+        assert reporting["role"] == "Author"
+        assert "sample standard deviation" in ar.skill_body(
+            ar.SKILL_RESULTS_REPORTING
+        )
+
+    def test_lists_the_wsdm_submission_skill_separately(self):
+        wsdm = next(
+            skill
+            for skill in ar.skill_catalog()
+            if skill["id"] == ar.SKILL_WSDM_SUBMISSION
+        )
+        assert wsdm["name"] == "wsdm-submission-readiness"
+        assert wsdm["role"] == "Author"
+        assert "nine-page technical-content boundary" in ar.skill_body(
+            ar.SKILL_WSDM_SUBMISSION
+        )
+
     def test_body_reads_a_catalogued_skill(self):
         first = ar.skill_catalog()[0]
         assert len(ar.skill_body(first["id"])) > 200
@@ -1558,7 +1582,14 @@ def test_resolve_invitation_prefers_an_open_window(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.parametrize(
-    "name", [ar.SKILL_STUDIO, ar.SKILL_AUTHOR, ar.SKILL_REVIEWER]
+    "name",
+    [
+        ar.SKILL_STUDIO,
+        ar.SKILL_AUTHOR,
+        ar.SKILL_REVIEWER,
+        ar.SKILL_RESULTS_REPORTING,
+        ar.SKILL_WSDM_SUBMISSION,
+    ],
 )
 def test_ar_skills_are_bundled(name: str) -> None:
     assert len(ar.ar_skill_text(name)) > 500
@@ -1608,6 +1639,52 @@ def test_author_prompts_point_at_the_figure_skills(tmp_path: Path) -> None:
         assert "teaser-figure-4" in prompt
         assert "results-figure-2" in prompt
         assert "SKILL.md" in prompt
+
+
+def test_author_prompts_inject_results_reporting(tmp_path: Path) -> None:
+    state = _paper_state()
+    prompts = (
+        ar.author_draft_prompt(tmp_path, tmp_path / "manuscript", state),
+        ar.author_round_prompt(tmp_path, tmp_path / "manuscript", state, 2),
+        ar.author_readiness_repair_prompt(
+            tmp_path,
+            tmp_path / "manuscript",
+            state,
+            2,
+            {"ready": False, "failed": []},
+        ),
+    )
+    for prompt in prompts:
+        assert "Results reporting and provenance" in prompt
+        assert "mean ± sample standard deviation" in prompt
+        assert "EXPERIMENT_DETAILS.md" in prompt
+        assert "WSDM submission requirements" not in prompt
+
+
+def test_wsdm_author_prompts_inject_only_the_wsdm_skill(tmp_path: Path) -> None:
+    state = _paper_state()
+    state["parent_slug"] = "wsdm2027"
+    assert ar.is_wsdm_paper(state)
+    prompts = (
+        ar.author_draft_prompt(tmp_path, tmp_path / "manuscript", state),
+        ar.author_round_prompt(tmp_path, tmp_path / "manuscript", state, 2),
+        ar.author_readiness_repair_prompt(
+            tmp_path,
+            tmp_path / "manuscript",
+            state,
+            2,
+            {"ready": False, "failed": []},
+        ),
+    )
+    for prompt in prompts:
+        assert "Results reporting and provenance" in prompt
+        assert "WSDM submission requirements" in prompt
+        assert r"\documentclass[sigconf,anonymous,review]{acmart}" in prompt
+        assert "appendix-backup.tex" in prompt
+
+    non_wsdm = _paper_state()
+    assert not ar.is_wsdm_paper(non_wsdm)
+    assert ar.wsdm_submission_block(non_wsdm) == ""
 
 
 def test_ar_skill_text_missing_file() -> None:


### PR DESCRIPTION
## Summary
- inject venue-independent result-reporting guidance into every Author prompt
- add WSDM-specific ACM, nine-page, ethics, and appendix readiness checks
- add WACV-specific template, track, eight-page, supplement, paper-ID, and delivery checks
- enforce main-paper interval placement, provenance hygiene, and final artifact naming with regression coverage

## Test plan
- [x] `uv run --extra dev pytest -q tests/test_ar_task.py` — 124 passed
- [x] `uv run --with pyyaml --extra dev pytest -q` — 357 passed
- [x] verified the current `main` changes merge without conflicts